### PR TITLE
Fix Assembly GetTypes() throwing exceptions

### DIFF
--- a/src/Nager.Country.Translation/AssemblieExtensions.cs
+++ b/src/Nager.Country.Translation/AssemblieExtensions.cs
@@ -8,7 +8,7 @@ namespace Nager.Country.Translation
     internal static class AssemblieExtensions
     {
         public static IEnumerable<Type> GetLoadableTypes(this Assembly assembly)
-        {​​​​​​​​
+        {
             if (assembly == null)
             {
                 throw new ArgumentNullException(nameof(assembly));

--- a/src/Nager.Country.Translation/AssemblieExtensions.cs
+++ b/src/Nager.Country.Translation/AssemblieExtensions.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Nager.Country.Translation
+{
+    internal static class AssemblieExtensions
+    {
+        public static IEnumerable<Type> GetLoadableTypes(this Assembly assembly)
+        {​​​​​​​​
+            if (assembly == null)
+            {
+                throw new ArgumentNullException(nameof(assembly));
+            }
+
+            try
+            {
+                return assembly.GetTypes();
+            }
+            catch (ReflectionTypeLoadException e)
+            {
+                return e.Types.Where(t => t != null);
+            }
+        }
+    }
+}

--- a/src/Nager.Country.Translation/TranslationProvider.cs
+++ b/src/Nager.Country.Translation/TranslationProvider.cs
@@ -20,7 +20,7 @@ namespace Nager.Country.Translation
 
             var interfaceType = typeof(ILanguageTranslation);
             var types = AppDomain.CurrentDomain.GetAssemblies()
-                .SelectMany(s => s.GetTypes())
+                .SelectMany(s => s.GetLoadableTypes())
                 .Where(p => interfaceType.IsAssignableFrom(p) && p.IsClass);
 
             foreach (var type in types)


### PR DESCRIPTION
Fix #5

Assembly GetTypes() can return errors when an assembly depends on a type from another assembly that is not yet loaded. There are other scenarios where GetTypes() can return errors.

This PR fix an issue where trying to instantiate a ``TranslationProvider`` can cause an exception.

In the PR I added an extension method that will get types that are loadable. The code contain a try/catch on ReflectionTypeLoadException.