### PR TITLE
add icelandic country translations

### DIFF
--- a/src/Nager.Country.Translation/CountryTranslations/AfghanistanCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/AfghanistanCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Afganisztán"),
             new TranslationInfo(LanguageCode.HY, "Աֆղանստան"),
             new TranslationInfo(LanguageCode.ID, "Afghanistan"),
+            new TranslationInfo(LanguageCode.IS, "Afgan­i­stan"),
             new TranslationInfo(LanguageCode.IT, "Afghanistan"),
             new TranslationInfo(LanguageCode.JA, "アフガニスタン"),
             new TranslationInfo(LanguageCode.KA, "ავღანეთი"),

--- a/src/Nager.Country.Translation/CountryTranslations/AlandIslandsCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/AlandIslandsCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Åland"),
             new TranslationInfo(LanguageCode.HY, "Ալանդյան կղզիներ"),
             new TranslationInfo(LanguageCode.ID, "Åland Islands"),
+            new TranslationInfo(LanguageCode.IS, "Álandseyjar"),
             new TranslationInfo(LanguageCode.IT, "Isole Åland"),
             new TranslationInfo(LanguageCode.JA, "オーランド諸島"),
             new TranslationInfo(LanguageCode.KA, "ალანდის კუნძულები"),

--- a/src/Nager.Country.Translation/CountryTranslations/AlbaniaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/AlbaniaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Albánia"),
             new TranslationInfo(LanguageCode.HY, "Ալբանիա"),
             new TranslationInfo(LanguageCode.ID, "Albania"),
+            new TranslationInfo(LanguageCode.IS, "Albanía"),
             new TranslationInfo(LanguageCode.IT, "Albania"),
             new TranslationInfo(LanguageCode.JA, "アルバニア"),
             new TranslationInfo(LanguageCode.KA, "ალბანეთი"),

--- a/src/Nager.Country.Translation/CountryTranslations/AlgeriaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/AlgeriaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Algéria"),
             new TranslationInfo(LanguageCode.HY, "Ալժիր"),
             new TranslationInfo(LanguageCode.ID, "Algeria"),
+            new TranslationInfo(LanguageCode.IS, "Alsír"),
             new TranslationInfo(LanguageCode.IT, "Algeria"),
             new TranslationInfo(LanguageCode.JA, "アルジェリア"),
             new TranslationInfo(LanguageCode.KA, "ალჟირი"),

--- a/src/Nager.Country.Translation/CountryTranslations/AmericanSamoaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/AmericanSamoaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Amerikai Szamoa"),
             new TranslationInfo(LanguageCode.HY, "Ամերիկյան Սամոա"),
             new TranslationInfo(LanguageCode.ID, "Amerika Serikat"),
+            new TranslationInfo(LanguageCode.IS, "Bandaríska Samóa"),
             new TranslationInfo(LanguageCode.IT, "Samoa Americane"),
             new TranslationInfo(LanguageCode.JA, "アメリカ領サモア"),
             new TranslationInfo(LanguageCode.KA, "ამერიკის სამოა"),

--- a/src/Nager.Country.Translation/CountryTranslations/AndorraCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/AndorraCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Andorra"),
             new TranslationInfo(LanguageCode.HY, "Անդորրա"),
             new TranslationInfo(LanguageCode.ID, "Andorra"),
+            new TranslationInfo(LanguageCode.IS, "Andorra"),
             new TranslationInfo(LanguageCode.IT, "Andorra"),
             new TranslationInfo(LanguageCode.JA, "アンドラ"),
             new TranslationInfo(LanguageCode.KA, "ანდორა"),

--- a/src/Nager.Country.Translation/CountryTranslations/AngolaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/AngolaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Angola"),
             new TranslationInfo(LanguageCode.HY, "Անգոլա"),
             new TranslationInfo(LanguageCode.ID, "Angola"),
+            new TranslationInfo(LanguageCode.IS, "Angóla"),
             new TranslationInfo(LanguageCode.IT, "Angola"),
             new TranslationInfo(LanguageCode.JA, "アンゴラ"),
             new TranslationInfo(LanguageCode.KA, "ანგოლა"),

--- a/src/Nager.Country.Translation/CountryTranslations/AnguillaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/AnguillaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Anguilla"),
             new TranslationInfo(LanguageCode.HY, "Անգուիլա"),
             new TranslationInfo(LanguageCode.ID, "Anguilla"),
+            new TranslationInfo(LanguageCode.IS, "Angvilla"),
             new TranslationInfo(LanguageCode.IT, "Anguilla"),
             new TranslationInfo(LanguageCode.JA, "アンギラ"),
             new TranslationInfo(LanguageCode.KA, "ანგვილა"),

--- a/src/Nager.Country.Translation/CountryTranslations/AntarcticaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/AntarcticaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Antarktisz"),
             new TranslationInfo(LanguageCode.HY, "Անտարկտիդա"),
             new TranslationInfo(LanguageCode.ID, "Antarctica"),
+            new TranslationInfo(LanguageCode.IS, "Antarktíka"),
             new TranslationInfo(LanguageCode.IT, "Antartide"),
             new TranslationInfo(LanguageCode.JA, "南極"),
             new TranslationInfo(LanguageCode.KA, "ანტარქტიკა"),

--- a/src/Nager.Country.Translation/CountryTranslations/AntiguaAndBarbudaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/AntiguaAndBarbudaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Antigua és Barbuda"),
             new TranslationInfo(LanguageCode.HY, "Անտիգուա և Բարբուդա"),
             new TranslationInfo(LanguageCode.ID, "Antigua dan Barbuda"),
+            new TranslationInfo(LanguageCode.IS, "Antígva og Barbúda"),
             new TranslationInfo(LanguageCode.IT, "Antigua e Barbuda"),
             new TranslationInfo(LanguageCode.JA, "アンティグア・バーブーダ"),
             new TranslationInfo(LanguageCode.KA, "ანტიგუა და ბარბუდა"),

--- a/src/Nager.Country.Translation/CountryTranslations/ArgentinaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/ArgentinaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Argentína"),
             new TranslationInfo(LanguageCode.HY, "Արգենտինա"),
             new TranslationInfo(LanguageCode.ID, "Argentina"),
+            new TranslationInfo(LanguageCode.IS, "Argentína"),
             new TranslationInfo(LanguageCode.IT, "Argentina"),
             new TranslationInfo(LanguageCode.JA, "アルゼンチン"),
             new TranslationInfo(LanguageCode.KA, "არგენტინა"),

--- a/src/Nager.Country.Translation/CountryTranslations/ArmeniaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/ArmeniaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Örményország"),
             new TranslationInfo(LanguageCode.HY, "Հայաստան"),
             new TranslationInfo(LanguageCode.ID, "Armenia"),
+            new TranslationInfo(LanguageCode.IS, "Armenía"),
             new TranslationInfo(LanguageCode.IT, "Armenia"),
             new TranslationInfo(LanguageCode.JA, "アルメニア"),
             new TranslationInfo(LanguageCode.KA, "სომხეთი"),

--- a/src/Nager.Country.Translation/CountryTranslations/ArubaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/ArubaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Aruba"),
             new TranslationInfo(LanguageCode.HY, "Արուբա"),
             new TranslationInfo(LanguageCode.ID, "Aruba"),
+            new TranslationInfo(LanguageCode.IS, "Arúba"),
             new TranslationInfo(LanguageCode.IT, "Aruba"),
             new TranslationInfo(LanguageCode.JA, "アルバ"),
             new TranslationInfo(LanguageCode.KA, "არუბა"),

--- a/src/Nager.Country.Translation/CountryTranslations/AustraliaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/AustraliaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Ausztrália"),
             new TranslationInfo(LanguageCode.HY, "Ավստրալիա"),
             new TranslationInfo(LanguageCode.ID, "Australia"),
+            new TranslationInfo(LanguageCode.IS, "Ástralía"),
             new TranslationInfo(LanguageCode.IT, "Australia"),
             new TranslationInfo(LanguageCode.JA, "オーストラリア"),
             new TranslationInfo(LanguageCode.KA, "ავსტრალია"),

--- a/src/Nager.Country.Translation/CountryTranslations/AustriaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/AustriaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Ausztria"),
             new TranslationInfo(LanguageCode.HY, "Ավստրիա"),
             new TranslationInfo(LanguageCode.ID, "Austria"),
+            new TranslationInfo(LanguageCode.IS, "Austurríki"),
             new TranslationInfo(LanguageCode.IT, "Austria"),
             new TranslationInfo(LanguageCode.JA, "オーストリア"),
             new TranslationInfo(LanguageCode.KA, "ავსტრია"),

--- a/src/Nager.Country.Translation/CountryTranslations/AzerbaijanCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/AzerbaijanCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Azerbajdzsán"),
             new TranslationInfo(LanguageCode.HY, "Ադրբեջան"),
             new TranslationInfo(LanguageCode.ID, "Azerbaijan"),
+            new TranslationInfo(LanguageCode.IS, "Aserb­aísjan"),
             new TranslationInfo(LanguageCode.IT, "Azerbaigian"),
             new TranslationInfo(LanguageCode.JA, "アゼルバイジャン"),
             new TranslationInfo(LanguageCode.KA, "აზერბაიჯანი"),

--- a/src/Nager.Country.Translation/CountryTranslations/BahamasCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/BahamasCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Bahama-szigetek"),
             new TranslationInfo(LanguageCode.HY, "Բահամաներ"),
             new TranslationInfo(LanguageCode.ID, "Bahama"),
+            new TranslationInfo(LanguageCode.IS, "Bahamaeyjar"),
             new TranslationInfo(LanguageCode.IT, "Bahamas"),
             new TranslationInfo(LanguageCode.JA, "バハマ"),
             new TranslationInfo(LanguageCode.KA, "ბაჰამის კუნძულები"),

--- a/src/Nager.Country.Translation/CountryTranslations/BahrainCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/BahrainCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Bahrein"),
             new TranslationInfo(LanguageCode.HY, "Բահրեյն"),
             new TranslationInfo(LanguageCode.ID, "Bahrain"),
+            new TranslationInfo(LanguageCode.IS, "Barein"),
             new TranslationInfo(LanguageCode.IT, "Bahrain"),
             new TranslationInfo(LanguageCode.JA, "バーレーン"),
             new TranslationInfo(LanguageCode.KA, "ბაჰრეინი"),

--- a/src/Nager.Country.Translation/CountryTranslations/BangladeshCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/BangladeshCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Banglades"),
             new TranslationInfo(LanguageCode.HY, "Բանգլադեշ"),
             new TranslationInfo(LanguageCode.ID, "Bangladesh"),
+            new TranslationInfo(LanguageCode.IS, "Bangladess"),
             new TranslationInfo(LanguageCode.IT, "Bangladesh"),
             new TranslationInfo(LanguageCode.JA, "バングラデシュ"),
             new TranslationInfo(LanguageCode.KA, "ბანგლადეში"),

--- a/src/Nager.Country.Translation/CountryTranslations/BarbadosCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/BarbadosCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Barbados"),
             new TranslationInfo(LanguageCode.HY, "Բարբադոս"),
             new TranslationInfo(LanguageCode.ID, "Barbados"),
+            new TranslationInfo(LanguageCode.IS, "Barbados"),
             new TranslationInfo(LanguageCode.IT, "Barbados"),
             new TranslationInfo(LanguageCode.JA, "バルバドス"),
             new TranslationInfo(LanguageCode.KA, "ბარბადოსი"),

--- a/src/Nager.Country.Translation/CountryTranslations/BelarusCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/BelarusCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Fehéroroszország"),
             new TranslationInfo(LanguageCode.HY, "Բելառուս"),
             new TranslationInfo(LanguageCode.ID, "Belarusia"),
+            new TranslationInfo(LanguageCode.IS, "Belarús"),
             new TranslationInfo(LanguageCode.IT, "Bielorussia"),
             new TranslationInfo(LanguageCode.JA, "ベラルーシ"),
             new TranslationInfo(LanguageCode.KA, "ბელარუსი"),

--- a/src/Nager.Country.Translation/CountryTranslations/BelgiumCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/BelgiumCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Belgium"),
             new TranslationInfo(LanguageCode.HY, "Բելգիա"),
             new TranslationInfo(LanguageCode.ID, "Belgia"),
+            new TranslationInfo(LanguageCode.IS, "Belgía"),
             new TranslationInfo(LanguageCode.IT, "Belgio"),
             new TranslationInfo(LanguageCode.JA, "ベルギー"),
             new TranslationInfo(LanguageCode.KA, "ბელგია"),

--- a/src/Nager.Country.Translation/CountryTranslations/BelizeCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/BelizeCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Belize"),
             new TranslationInfo(LanguageCode.HY, "Բելիզ"),
             new TranslationInfo(LanguageCode.ID, "Belize"),
+            new TranslationInfo(LanguageCode.IS, "Belís"),
             new TranslationInfo(LanguageCode.IT, "Belize"),
             new TranslationInfo(LanguageCode.JA, "ベリーズ"),
             new TranslationInfo(LanguageCode.KA, "ბელიზი"),

--- a/src/Nager.Country.Translation/CountryTranslations/BeninCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/BeninCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Benin"),
             new TranslationInfo(LanguageCode.HY, "Բենին"),
             new TranslationInfo(LanguageCode.ID, "Benin"),
+            new TranslationInfo(LanguageCode.IS, "Benín"),
             new TranslationInfo(LanguageCode.IT, "Benin"),
             new TranslationInfo(LanguageCode.JA, "ベナン"),
             new TranslationInfo(LanguageCode.KA, "ბენინი"),

--- a/src/Nager.Country.Translation/CountryTranslations/BermudaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/BermudaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Bermuda"),
             new TranslationInfo(LanguageCode.HY, "Բերմուդներ"),
             new TranslationInfo(LanguageCode.ID, "Bermuda"),
+            new TranslationInfo(LanguageCode.IS, "Bermúda"),
             new TranslationInfo(LanguageCode.IT, "Bermuda"),
             new TranslationInfo(LanguageCode.JA, "バミューダ"),
             new TranslationInfo(LanguageCode.KA, "ბერმუდა"),

--- a/src/Nager.Country.Translation/CountryTranslations/BhutanCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/BhutanCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Bhután"),
             new TranslationInfo(LanguageCode.HY, "Բութան"),
             new TranslationInfo(LanguageCode.ID, "Bhutan"),
+            new TranslationInfo(LanguageCode.IS, "Bútan"),
             new TranslationInfo(LanguageCode.IT, "Bhutan"),
             new TranslationInfo(LanguageCode.JA, "ブータン"),
             new TranslationInfo(LanguageCode.KA, "ბუტანი"),

--- a/src/Nager.Country.Translation/CountryTranslations/BoliviaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/BoliviaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Bolívia"),
             new TranslationInfo(LanguageCode.HY, "Բոլիվիա"),
             new TranslationInfo(LanguageCode.ID, "Bolivia"),
+            new TranslationInfo(LanguageCode.IS, "Bólivía"),
             new TranslationInfo(LanguageCode.IT, "Bolivia"),
             new TranslationInfo(LanguageCode.JA, "ボリビア多民族国"),
             new TranslationInfo(LanguageCode.KA, "ბოლივია"),

--- a/src/Nager.Country.Translation/CountryTranslations/BosniaandHerzegovinaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/BosniaandHerzegovinaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Bosznia-Hercegovina"),
             new TranslationInfo(LanguageCode.HY, "Բոսնիա և Հերցեգովինա"),
             new TranslationInfo(LanguageCode.ID, "Bosnia dan Herzegovina"),
+            new TranslationInfo(LanguageCode.IS, "Bosnía og Hersegóvína"),
             new TranslationInfo(LanguageCode.IT, "Bosnia ed Erzegovina"),
             new TranslationInfo(LanguageCode.JA, "ボスニア・ヘルツェゴビナ"),
             new TranslationInfo(LanguageCode.KA, "ბოსნია და ჰერცეგოვინა"),

--- a/src/Nager.Country.Translation/CountryTranslations/BotswanaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/BotswanaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Botswana"),
             new TranslationInfo(LanguageCode.HY, "Բոթսվանա"),
             new TranslationInfo(LanguageCode.ID, "Botswana"),
+            new TranslationInfo(LanguageCode.IS, "Botsvana"),
             new TranslationInfo(LanguageCode.IT, "Botswana"),
             new TranslationInfo(LanguageCode.JA, "ボツワナ"),
             new TranslationInfo(LanguageCode.KA, "ბოტსვანა"),

--- a/src/Nager.Country.Translation/CountryTranslations/BouvetIslandCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/BouvetIslandCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Bouvet-sziget"),
             new TranslationInfo(LanguageCode.HY, "Բուվե կղզի"),
             new TranslationInfo(LanguageCode.ID, "Kepulauan Bouvet"),
+            new TranslationInfo(LanguageCode.IS, "Bouveteyja"),
             new TranslationInfo(LanguageCode.IT, "Isola Bouvet"),
             new TranslationInfo(LanguageCode.JA, "ブーベ島"),
             new TranslationInfo(LanguageCode.KA, "ბუვე"),

--- a/src/Nager.Country.Translation/CountryTranslations/BrazilCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/BrazilCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Brazília"),
             new TranslationInfo(LanguageCode.HY, "Բրազիլիա"),
             new TranslationInfo(LanguageCode.ID, "Brasil"),
+            new TranslationInfo(LanguageCode.IS, "Brasilía"),
             new TranslationInfo(LanguageCode.IT, "Brasile"),
             new TranslationInfo(LanguageCode.JA, "ブラジル"),
             new TranslationInfo(LanguageCode.KA, "ბრაზილია"),

--- a/src/Nager.Country.Translation/CountryTranslations/BritishVirginIslandsCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/BritishVirginIslandsCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Brit Virgin-szigetek"),
             new TranslationInfo(LanguageCode.HY, "Բրիտանական Վիրջինյան կղզիներ"),
             new TranslationInfo(LanguageCode.ID, "Virgin Islands, British"),
+            new TranslationInfo(LanguageCode.IS, "Bresku Jómfrúaeyjar"),
             new TranslationInfo(LanguageCode.IT, "Isole Vergini Britanniche"),
             new TranslationInfo(LanguageCode.JA, "イギリス領ヴァージン諸島"),
             new TranslationInfo(LanguageCode.KA, "ბრიტანეთის ვირჯინის კუნძულები"),

--- a/src/Nager.Country.Translation/CountryTranslations/BruneiCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/BruneiCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Brunei"),
             new TranslationInfo(LanguageCode.HY, "Բրունեյ"),
             new TranslationInfo(LanguageCode.ID, "Brunei Darussalam"),
+            new TranslationInfo(LanguageCode.IS, "Brúnei"),
             new TranslationInfo(LanguageCode.IT, "Brunei"),
             new TranslationInfo(LanguageCode.JA, "ブルネイ・ダルサラーム"),
             new TranslationInfo(LanguageCode.KA, "ბრუნეი"),

--- a/src/Nager.Country.Translation/CountryTranslations/BulgariaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/BulgariaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Bulgária"),
             new TranslationInfo(LanguageCode.HY, "Բուլղարիա"),
             new TranslationInfo(LanguageCode.ID, "Bulgaria"),
+            new TranslationInfo(LanguageCode.IS, "Búlgaría"),
             new TranslationInfo(LanguageCode.IT, "Bulgaria"),
             new TranslationInfo(LanguageCode.JA, "ブルガリア"),
             new TranslationInfo(LanguageCode.KA, "ბულგარეთი"),

--- a/src/Nager.Country.Translation/CountryTranslations/BurkinaFasoCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/BurkinaFasoCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Burkina Faso"),
             new TranslationInfo(LanguageCode.HY, "Բուրկինա Ֆասո"),
             new TranslationInfo(LanguageCode.ID, "Burkina Faso"),
+            new TranslationInfo(LanguageCode.IS, "Búrkína Fasó"),
             new TranslationInfo(LanguageCode.IT, "Burkina Faso"),
             new TranslationInfo(LanguageCode.JA, "ブルキナファソ"),
             new TranslationInfo(LanguageCode.KA, "ბურკინა-ფასო"),

--- a/src/Nager.Country.Translation/CountryTranslations/BurundiCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/BurundiCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Burundi"),
             new TranslationInfo(LanguageCode.HY, "Բուրունդի"),
             new TranslationInfo(LanguageCode.ID, "Burundi"),
+            new TranslationInfo(LanguageCode.IS, "Búrúndí"),
             new TranslationInfo(LanguageCode.IT, "Burundi"),
             new TranslationInfo(LanguageCode.JA, "ブルンジ"),
             new TranslationInfo(LanguageCode.KA, "ბურუნდი"),

--- a/src/Nager.Country.Translation/CountryTranslations/CambodiaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/CambodiaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Kambodzsa"),
             new TranslationInfo(LanguageCode.HY, "Կամբոջա"),
             new TranslationInfo(LanguageCode.ID, "Kamboja"),
+            new TranslationInfo(LanguageCode.IS, "Kambódía"),
             new TranslationInfo(LanguageCode.IT, "Cambogia"),
             new TranslationInfo(LanguageCode.JA, "カンボジア"),
             new TranslationInfo(LanguageCode.KA, "კამბოჯა"),

--- a/src/Nager.Country.Translation/CountryTranslations/CameroonCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/CameroonCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Kamerun"),
             new TranslationInfo(LanguageCode.HY, "Կամերուն"),
             new TranslationInfo(LanguageCode.ID, "Kamerun"),
+            new TranslationInfo(LanguageCode.IS, "Kamerún"),
             new TranslationInfo(LanguageCode.IT, "Camerun"),
             new TranslationInfo(LanguageCode.JA, "カメルーン"),
             new TranslationInfo(LanguageCode.KA, "კამერუნი"),

--- a/src/Nager.Country.Translation/CountryTranslations/CanadaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/CanadaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Kanada"),
             new TranslationInfo(LanguageCode.HY, "Կանադա"),
             new TranslationInfo(LanguageCode.ID, "Kanada"),
+            new TranslationInfo(LanguageCode.IS, "Kanada"),
             new TranslationInfo(LanguageCode.IT, "Canada"),
             new TranslationInfo(LanguageCode.JA, "カナダ"),
             new TranslationInfo(LanguageCode.KA, "კანადა"),

--- a/src/Nager.Country.Translation/CountryTranslations/CapeVerdeCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/CapeVerdeCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Zöld-foki Köztársaság"),
             new TranslationInfo(LanguageCode.HY, "Կաբո Վերդե"),
             new TranslationInfo(LanguageCode.ID, "Tanjung Verde"),
+            new TranslationInfo(LanguageCode.IS, "Grænhöfðaeyjar"),
             new TranslationInfo(LanguageCode.IT, "Capo Verde"),
             new TranslationInfo(LanguageCode.JA, "カーボベルデ"),
             new TranslationInfo(LanguageCode.KA, "კაბო-ვერდე"),

--- a/src/Nager.Country.Translation/CountryTranslations/CaymanIslandsCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/CaymanIslandsCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Kajmán-szigetek"),
             new TranslationInfo(LanguageCode.HY, "Կայմանյան կղզիներ"),
             new TranslationInfo(LanguageCode.ID, "Kepulauan Cayman"),
+            new TranslationInfo(LanguageCode.IS, "Caymaneyjar"),
             new TranslationInfo(LanguageCode.IT, "Isole Cayman"),
             new TranslationInfo(LanguageCode.JA, "ケイマン諸島"),
             new TranslationInfo(LanguageCode.KA, "კაიმანის კუნძულები"),

--- a/src/Nager.Country.Translation/CountryTranslations/CentralAfricanRepublicCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/CentralAfricanRepublicCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Közép-afrikai Köztársaság"),
             new TranslationInfo(LanguageCode.HY, "Կենտրոնական Աֆրիկյան Հանրապետություն"),
             new TranslationInfo(LanguageCode.ID, "Afrika Tengah"),
+            new TranslationInfo(LanguageCode.IS, "Mið-Afríkulýðveldið"),
             new TranslationInfo(LanguageCode.IT, "Repubblica Centrafricana"),
             new TranslationInfo(LanguageCode.JA, "中央アフリカ共和国"),
             new TranslationInfo(LanguageCode.KA, "ცენტრალური აფრიკის რესპუბლიკა"),

--- a/src/Nager.Country.Translation/CountryTranslations/ChadCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/ChadCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Csád"),
             new TranslationInfo(LanguageCode.HY, "Չադ"),
             new TranslationInfo(LanguageCode.ID, "Chad"),
+            new TranslationInfo(LanguageCode.IS, "Tjad"),
             new TranslationInfo(LanguageCode.IT, "Ciad"),
             new TranslationInfo(LanguageCode.JA, "チャド"),
             new TranslationInfo(LanguageCode.KA, "ჩადი"),

--- a/src/Nager.Country.Translation/CountryTranslations/ChileCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/ChileCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Chile"),
             new TranslationInfo(LanguageCode.HY, "Չիլի"),
             new TranslationInfo(LanguageCode.ID, "Chile"),
+            new TranslationInfo(LanguageCode.IS, "Chile"),
             new TranslationInfo(LanguageCode.IT, "Cile"),
             new TranslationInfo(LanguageCode.JA, "チリ"),
             new TranslationInfo(LanguageCode.KA, "ჩილე"),

--- a/src/Nager.Country.Translation/CountryTranslations/ChinaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/ChinaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Kína"),
             new TranslationInfo(LanguageCode.HY, "Չինաստան"),
             new TranslationInfo(LanguageCode.ID, "China"),
+            new TranslationInfo(LanguageCode.IS, "Kína"),
             new TranslationInfo(LanguageCode.IT, "Cina"),
             new TranslationInfo(LanguageCode.JA, "中華人民共和国"),
             new TranslationInfo(LanguageCode.KA, "ჩინეთი"),

--- a/src/Nager.Country.Translation/CountryTranslations/ChristmasIslandCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/ChristmasIslandCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Karácsony-sziget"),
             new TranslationInfo(LanguageCode.HY, "Սուրբ Ծննդյան կղզի"),
             new TranslationInfo(LanguageCode.ID, "Pulau Natal"),
+            new TranslationInfo(LanguageCode.IS, "Jólaey"),
             new TranslationInfo(LanguageCode.IT, "Isola del Natale"),
             new TranslationInfo(LanguageCode.JA, "クリスマス島"),
             new TranslationInfo(LanguageCode.KA, "შობის კუნძული"),

--- a/src/Nager.Country.Translation/CountryTranslations/CocosIslandsCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/CocosIslandsCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Kókusz (Keeling)-szigetek"),
             new TranslationInfo(LanguageCode.HY, "Կոկոսյան (Քիլինգ) կղզիներ"),
             new TranslationInfo(LanguageCode.ID, "Kepulauan Cocos (Keeling)"),
+            new TranslationInfo(LanguageCode.IS, "Kókoseyjar"),
             new TranslationInfo(LanguageCode.IT, "Isole Cocos e Keeling"),
             new TranslationInfo(LanguageCode.JA, "ココス（キーリング）諸島"),
             new TranslationInfo(LanguageCode.KA, "ქოქოსის (კილინგის) კუნძულები"),

--- a/src/Nager.Country.Translation/CountryTranslations/ColombiaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/ColombiaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Kolumbia"),
             new TranslationInfo(LanguageCode.HY, "Կոլումբիա"),
             new TranslationInfo(LanguageCode.ID, "Kolombia"),
+            new TranslationInfo(LanguageCode.IS, "Kólumbía"),
             new TranslationInfo(LanguageCode.IT, "Colombia"),
             new TranslationInfo(LanguageCode.JA, "コロンビア"),
             new TranslationInfo(LanguageCode.KA, "კოლუმბია"),

--- a/src/Nager.Country.Translation/CountryTranslations/ComorosCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/ComorosCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Comore-szigetek"),
             new TranslationInfo(LanguageCode.HY, "Կոմորյան կղզիներ"),
             new TranslationInfo(LanguageCode.ID, "Komoro"),
+            new TranslationInfo(LanguageCode.IS, "Kómorur"),
             new TranslationInfo(LanguageCode.IT, "Comore"),
             new TranslationInfo(LanguageCode.JA, "小諸"),
             new TranslationInfo(LanguageCode.KA, "კომორის კუნძულები"),

--- a/src/Nager.Country.Translation/CountryTranslations/CongoCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/CongoCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Kongói Demokratikus Köztársaság"),
             new TranslationInfo(LanguageCode.HY, "Կոնգո - Կինշասա"),
             new TranslationInfo(LanguageCode.ID, "Republik Demokratik Kongo"),
+            new TranslationInfo(LanguageCode.IS, "Kongó"),
             new TranslationInfo(LanguageCode.IT, "Repubblica Democratica del Congo"),
             new TranslationInfo(LanguageCode.JA, "コンゴ民主共和国"),
             new TranslationInfo(LanguageCode.KA, "კონგო - კინშასა"),

--- a/src/Nager.Country.Translation/CountryTranslations/CookIslandsCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/CookIslandsCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Cook-szigetek"),
             new TranslationInfo(LanguageCode.HY, "Կուկի կղզիներ"),
             new TranslationInfo(LanguageCode.ID, "Kepulauan Cook"),
+            new TranslationInfo(LanguageCode.IS, "Cookseyjar"),
             new TranslationInfo(LanguageCode.IT, "Isole Cook"),
             new TranslationInfo(LanguageCode.JA, "クック諸島"),
             new TranslationInfo(LanguageCode.KA, "კუკის კუნძულები"),

--- a/src/Nager.Country.Translation/CountryTranslations/CostaRicaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/CostaRicaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Costa Rica"),
             new TranslationInfo(LanguageCode.HY, "Կոստա Ռիկա"),
             new TranslationInfo(LanguageCode.ID, "Kosta Rika"),
+            new TranslationInfo(LanguageCode.IS, "Kosta Ríka"),
             new TranslationInfo(LanguageCode.IT, "Costa Rica"),
             new TranslationInfo(LanguageCode.JA, "コスタリカ"),
             new TranslationInfo(LanguageCode.KA, "კოსტა-რიკა"),

--- a/src/Nager.Country.Translation/CountryTranslations/CroatiaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/CroatiaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Horvátország"),
             new TranslationInfo(LanguageCode.HY, "Խորվաթիա"),
             new TranslationInfo(LanguageCode.ID, "Kroasia"),
+            new TranslationInfo(LanguageCode.IS, "Króatía"),
             new TranslationInfo(LanguageCode.IT, "Croazia"),
             new TranslationInfo(LanguageCode.JA, "クロアチア"),
             new TranslationInfo(LanguageCode.KA, "ხორვატია"),

--- a/src/Nager.Country.Translation/CountryTranslations/CubaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/CubaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Kuba"),
             new TranslationInfo(LanguageCode.HY, "Կուբա"),
             new TranslationInfo(LanguageCode.ID, "Kuba"),
+            new TranslationInfo(LanguageCode.IS, "Kúba"),
             new TranslationInfo(LanguageCode.IT, "Cuba"),
             new TranslationInfo(LanguageCode.JA, "キューバ"),
             new TranslationInfo(LanguageCode.KA, "კუბა"),

--- a/src/Nager.Country.Translation/CountryTranslations/CuracaoCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/CuracaoCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Curaçao"),
             new TranslationInfo(LanguageCode.HY, "Կյուրասաո"),
             new TranslationInfo(LanguageCode.ID, "Curaçao"),
+            new TranslationInfo(LanguageCode.IS, "Curaçao"),
             new TranslationInfo(LanguageCode.IT, "Curaçao"),
             new TranslationInfo(LanguageCode.JA, "キュラソー"),
             new TranslationInfo(LanguageCode.KA, "კიურასაო"),

--- a/src/Nager.Country.Translation/CountryTranslations/CyprusCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/CyprusCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Ciprus"),
             new TranslationInfo(LanguageCode.HY, "Կիպրոս"),
             new TranslationInfo(LanguageCode.ID, "Siprus"),
+            new TranslationInfo(LanguageCode.IS, "Kýpur"),
             new TranslationInfo(LanguageCode.IT, "Cipro"),
             new TranslationInfo(LanguageCode.JA, "キプロス"),
             new TranslationInfo(LanguageCode.KA, "კვიპროსი"),

--- a/src/Nager.Country.Translation/CountryTranslations/CzechRepublicCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/CzechRepublicCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Csehország"),
             new TranslationInfo(LanguageCode.HY, "Չեխիա"),
             new TranslationInfo(LanguageCode.ID, "Republik Ceko"),
+            new TranslationInfo(LanguageCode.IS, "Tékkland"),
             new TranslationInfo(LanguageCode.IT, "Repubblica Ceca"),
             new TranslationInfo(LanguageCode.JA, "チェコ"),
             new TranslationInfo(LanguageCode.KA, "ჩეხეთის რესპუბლიკა"),

--- a/src/Nager.Country.Translation/CountryTranslations/DenmarkCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/DenmarkCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Dánia"),
             new TranslationInfo(LanguageCode.HY, "Դանիա"),
             new TranslationInfo(LanguageCode.ID, "Denmark"),
+            new TranslationInfo(LanguageCode.IS, "Danmörk"),
             new TranslationInfo(LanguageCode.IT, "Danimarca"),
             new TranslationInfo(LanguageCode.JA, "デンマーク"),
             new TranslationInfo(LanguageCode.KA, "დანია"),

--- a/src/Nager.Country.Translation/CountryTranslations/DjiboutiCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/DjiboutiCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Dzsibuti"),
             new TranslationInfo(LanguageCode.HY, "Ջիբութի"),
             new TranslationInfo(LanguageCode.ID, "Djibouti"),
+            new TranslationInfo(LanguageCode.IS, "Djíbútí"),
             new TranslationInfo(LanguageCode.IT, "Gibuti"),
             new TranslationInfo(LanguageCode.JA, "ジブチ"),
             new TranslationInfo(LanguageCode.KA, "ჯიბუტი"),

--- a/src/Nager.Country.Translation/CountryTranslations/DominicaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/DominicaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Dominikai Közösség"),
             new TranslationInfo(LanguageCode.HY, "Դոմինիկա"),
             new TranslationInfo(LanguageCode.ID, "Dominika"),
+            new TranslationInfo(LanguageCode.IS, "Dóminíka"),
             new TranslationInfo(LanguageCode.IT, "Dominica"),
             new TranslationInfo(LanguageCode.JA, "ドミニカ国"),
             new TranslationInfo(LanguageCode.KA, "დომინიკა"),

--- a/src/Nager.Country.Translation/CountryTranslations/DominicanRepublicCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/DominicanRepublicCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Dominikai Köztársaság"),
             new TranslationInfo(LanguageCode.HY, "Դոմինիկյան Հանրապետություն"),
             new TranslationInfo(LanguageCode.ID, "Republik Dominika"),
+            new TranslationInfo(LanguageCode.IS, "Dóminíska lýðveldið"),
             new TranslationInfo(LanguageCode.IT, "Repubblica Dominicana"),
             new TranslationInfo(LanguageCode.JA, "ドミニカ共和国"),
             new TranslationInfo(LanguageCode.KA, "დომინიკელთა რესპუბლიკა"),

--- a/src/Nager.Country.Translation/CountryTranslations/EcuadorCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/EcuadorCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Ecuador"),
             new TranslationInfo(LanguageCode.HY, "Էկվադոր"),
             new TranslationInfo(LanguageCode.ID, "Ekuador"),
+            new TranslationInfo(LanguageCode.IS, "Ekvador"),
             new TranslationInfo(LanguageCode.IT, "Ecuador"),
             new TranslationInfo(LanguageCode.JA, "エクアドル"),
             new TranslationInfo(LanguageCode.KA, "ეკვადორი"),

--- a/src/Nager.Country.Translation/CountryTranslations/EgyptCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/EgyptCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Egyiptom"),
             new TranslationInfo(LanguageCode.HY, "Եգիպտոս"),
             new TranslationInfo(LanguageCode.ID, "Mesir"),
+            new TranslationInfo(LanguageCode.IS, "Egyptaland"),
             new TranslationInfo(LanguageCode.IT, "Egitto"),
             new TranslationInfo(LanguageCode.JA, "エジプト"),
             new TranslationInfo(LanguageCode.KA, "ეგვიპტე"),

--- a/src/Nager.Country.Translation/CountryTranslations/ElSalvadorCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/ElSalvadorCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Salvador"),
             new TranslationInfo(LanguageCode.HY, "Սալվադոր"),
             new TranslationInfo(LanguageCode.ID, "El Salvador"),
+            new TranslationInfo(LanguageCode.IS, "El Salvador"),
             new TranslationInfo(LanguageCode.IT, "El Salvador"),
             new TranslationInfo(LanguageCode.JA, "エルサルバドル"),
             new TranslationInfo(LanguageCode.KA, "სალვადორი"),

--- a/src/Nager.Country.Translation/CountryTranslations/EquatorialGuineaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/EquatorialGuineaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Egyenlítői-Guinea"),
             new TranslationInfo(LanguageCode.HY, "Հասարակածային Գվինեա"),
             new TranslationInfo(LanguageCode.ID, "Guinea Khatulistiwa"),
+            new TranslationInfo(LanguageCode.IS, "Miðbaugs-Gínea"),
             new TranslationInfo(LanguageCode.IT, "Guinea Equatoriale"),
             new TranslationInfo(LanguageCode.JA, "赤道ギニア"),
             new TranslationInfo(LanguageCode.KA, "ეკვატორული გვინეა"),

--- a/src/Nager.Country.Translation/CountryTranslations/EstoniaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/EstoniaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Észtország"),
             new TranslationInfo(LanguageCode.HY, "Էստոնիա"),
             new TranslationInfo(LanguageCode.ID, "Estonia"),
+            new TranslationInfo(LanguageCode.IS, "Eistland"),
             new TranslationInfo(LanguageCode.IT, "Estonia"),
             new TranslationInfo(LanguageCode.JA, "エストニア"),
             new TranslationInfo(LanguageCode.KA, "ესტონეთი"),

--- a/src/Nager.Country.Translation/CountryTranslations/EthiopiaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/EthiopiaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Etiópia"),
             new TranslationInfo(LanguageCode.HY, "Եթովպիա"),
             new TranslationInfo(LanguageCode.ID, "Ethiopia"),
+            new TranslationInfo(LanguageCode.IS, "Eþíópía"),
             new TranslationInfo(LanguageCode.IT, "Etiopia"),
             new TranslationInfo(LanguageCode.JA, "エチオピア"),
             new TranslationInfo(LanguageCode.KA, "ეთიოპია"),

--- a/src/Nager.Country.Translation/CountryTranslations/FalklandIslandsCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/FalklandIslandsCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Falkland-szigetek"),
             new TranslationInfo(LanguageCode.HY, "Ֆոլքլենդյան կղզիներ"),
             new TranslationInfo(LanguageCode.ID, "Kepulauan Falkland(Malvinas)"),
+            new TranslationInfo(LanguageCode.IS, "Falklandseyjar"),
             new TranslationInfo(LanguageCode.IT, "Isole Falkland"),
             new TranslationInfo(LanguageCode.JA, "フォークランド（マルビナス）諸島"),
             new TranslationInfo(LanguageCode.KA, "ფოლკლენდის კუნძულები"),

--- a/src/Nager.Country.Translation/CountryTranslations/FaroeIslandsCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/FaroeIslandsCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Feröer"),
             new TranslationInfo(LanguageCode.HY, "Ֆարերյան կղզիներ"),
             new TranslationInfo(LanguageCode.ID, "Kepulauan Faroe"),
+            new TranslationInfo(LanguageCode.IS, "Færeyjar"),
             new TranslationInfo(LanguageCode.IT, "Isole Fær Øer"),
             new TranslationInfo(LanguageCode.JA, "フェロー諸島"),
             new TranslationInfo(LanguageCode.KA, "ფარერის კუნძულები"),

--- a/src/Nager.Country.Translation/CountryTranslations/FijiCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/FijiCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Fidzsi-szigetek"),
             new TranslationInfo(LanguageCode.HY, "Ֆիջի"),
             new TranslationInfo(LanguageCode.ID, "Fiji"),
+            new TranslationInfo(LanguageCode.IS, "Fídjí"),
             new TranslationInfo(LanguageCode.IT, "Figi"),
             new TranslationInfo(LanguageCode.JA, "フィジー"),
             new TranslationInfo(LanguageCode.KA, "ფიჯი"),

--- a/src/Nager.Country.Translation/CountryTranslations/FinlandCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/FinlandCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Finnország"),
             new TranslationInfo(LanguageCode.HY, "Ֆինլանդիա"),
             new TranslationInfo(LanguageCode.ID, "Finlandia"),
+            new TranslationInfo(LanguageCode.IS, "Finnland"),
             new TranslationInfo(LanguageCode.IT, "Finlandia"),
             new TranslationInfo(LanguageCode.JA, "フィンランド"),
             new TranslationInfo(LanguageCode.KA, "ფინეთი"),

--- a/src/Nager.Country.Translation/CountryTranslations/FranceCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/FranceCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Franciaország"),
             new TranslationInfo(LanguageCode.HY, "Ֆրանսիա"),
             new TranslationInfo(LanguageCode.ID, "Perancis"),
+            new TranslationInfo(LanguageCode.IS, "Frakkland"),
             new TranslationInfo(LanguageCode.IT, "Francia"),
             new TranslationInfo(LanguageCode.JA, "フランス"),
             new TranslationInfo(LanguageCode.KA, "საფრანგეთი"),

--- a/src/Nager.Country.Translation/CountryTranslations/FrenchPolynesiaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/FrenchPolynesiaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Francia Polinézia"),
             new TranslationInfo(LanguageCode.HY, "Ֆրանսիական Պոլինեզիա"),
             new TranslationInfo(LanguageCode.ID, "Polinesia Perancis"),
+            new TranslationInfo(LanguageCode.IS, "Franska Pólýnesía"),
             new TranslationInfo(LanguageCode.IT, "Polinesia Francese"),
             new TranslationInfo(LanguageCode.JA, "フランス領ポリネシア"),
             new TranslationInfo(LanguageCode.KA, "საფრანგეთის პოლინეზია"),

--- a/src/Nager.Country.Translation/CountryTranslations/GabonCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/GabonCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Gabon"),
             new TranslationInfo(LanguageCode.HY, "Գաբոն"),
             new TranslationInfo(LanguageCode.ID, "Gabon"),
+            new TranslationInfo(LanguageCode.IS, "Gabon"),
             new TranslationInfo(LanguageCode.IT, "Gabon"),
             new TranslationInfo(LanguageCode.JA, "ガボン"),
             new TranslationInfo(LanguageCode.KA, "გაბონი"),

--- a/src/Nager.Country.Translation/CountryTranslations/GambiaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/GambiaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Gambia"),
             new TranslationInfo(LanguageCode.HY, "Գամբիա"),
             new TranslationInfo(LanguageCode.ID, "Gambia"),
+            new TranslationInfo(LanguageCode.IS, "Gambía"),
             new TranslationInfo(LanguageCode.IT, "Gambia"),
             new TranslationInfo(LanguageCode.JA, "ガンビア"),
             new TranslationInfo(LanguageCode.KA, "გამბია"),

--- a/src/Nager.Country.Translation/CountryTranslations/GeorgiaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/GeorgiaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Grúzia"),
             new TranslationInfo(LanguageCode.HY, "Վրաստան"),
             new TranslationInfo(LanguageCode.ID, "Georgia"),
+            new TranslationInfo(LanguageCode.IS, "Georgía"),
             new TranslationInfo(LanguageCode.IT, "Georgia"),
             new TranslationInfo(LanguageCode.JA, "ジョージア"),
             new TranslationInfo(LanguageCode.KA, "საქართველო"),

--- a/src/Nager.Country.Translation/CountryTranslations/GermanyCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/GermanyCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Németország"),
             new TranslationInfo(LanguageCode.HY, "Գերմանիա"),
             new TranslationInfo(LanguageCode.ID, "Jerman"),
+            new TranslationInfo(LanguageCode.IS, "Þýskaland"),
             new TranslationInfo(LanguageCode.IT, "Germania"),
             new TranslationInfo(LanguageCode.JA, "ドイツ"),
             new TranslationInfo(LanguageCode.KA, "გერმანია"),

--- a/src/Nager.Country.Translation/CountryTranslations/GhanaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/GhanaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Ghána"),
             new TranslationInfo(LanguageCode.HY, "Գանա"),
             new TranslationInfo(LanguageCode.ID, "Ghana"),
+            new TranslationInfo(LanguageCode.IS, "Gana"),
             new TranslationInfo(LanguageCode.IT, "Ghana"),
             new TranslationInfo(LanguageCode.JA, "ガーナ"),
             new TranslationInfo(LanguageCode.KA, "განა"),

--- a/src/Nager.Country.Translation/CountryTranslations/GibraltarCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/GibraltarCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Gibraltár"),
             new TranslationInfo(LanguageCode.HY, "Ջիբրալթար"),
             new TranslationInfo(LanguageCode.ID, "Gibraltar"),
+            new TranslationInfo(LanguageCode.IS, "Gíbraltar"),
             new TranslationInfo(LanguageCode.IT, "Gibilterra"),
             new TranslationInfo(LanguageCode.JA, "ジブラルタル"),
             new TranslationInfo(LanguageCode.KA, "გიბრალტარი"),

--- a/src/Nager.Country.Translation/CountryTranslations/GreeceCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/GreeceCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Görögország"),
             new TranslationInfo(LanguageCode.HY, "Հունաստան"),
             new TranslationInfo(LanguageCode.ID, "Yunani"),
+            new TranslationInfo(LanguageCode.IS, "Grikkland"),
             new TranslationInfo(LanguageCode.IT, "Grecia"),
             new TranslationInfo(LanguageCode.JA, "ギリシャ"),
             new TranslationInfo(LanguageCode.KA, "საბერძნეთი"),

--- a/src/Nager.Country.Translation/CountryTranslations/GreenlandCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/GreenlandCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Grönland"),
             new TranslationInfo(LanguageCode.HY, "Գրենլանդիա"),
             new TranslationInfo(LanguageCode.ID, "Greenland"),
+            new TranslationInfo(LanguageCode.IS, "Grænland"),
             new TranslationInfo(LanguageCode.IT, "Groenlandia"),
             new TranslationInfo(LanguageCode.JA, "グリーンランド"),
             new TranslationInfo(LanguageCode.KA, "გრენლანდია"),

--- a/src/Nager.Country.Translation/CountryTranslations/GrenadaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/GrenadaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Grenada"),
             new TranslationInfo(LanguageCode.HY, "Գրենադա"),
             new TranslationInfo(LanguageCode.ID, "Grenada"),
+            new TranslationInfo(LanguageCode.IS, "Grenada"),
             new TranslationInfo(LanguageCode.IT, "Grenada"),
             new TranslationInfo(LanguageCode.JA, "グレナダ"),
             new TranslationInfo(LanguageCode.KA, "გრენადა"),

--- a/src/Nager.Country.Translation/CountryTranslations/GuadeloupeCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/GuadeloupeCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Guadeloupe"),
             new TranslationInfo(LanguageCode.HY, "Գվադելուպա"),
             new TranslationInfo(LanguageCode.ID, "Guadeloupe"),
+            new TranslationInfo(LanguageCode.IS, "Gvadelúpeyjar"),
             new TranslationInfo(LanguageCode.IT, "Guadalupa"),
             new TranslationInfo(LanguageCode.JA, "グアドループ"),
             new TranslationInfo(LanguageCode.KA, "გვადელუპა"),

--- a/src/Nager.Country.Translation/CountryTranslations/GuamCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/GuamCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Guam"),
             new TranslationInfo(LanguageCode.HY, "Գուամ"),
             new TranslationInfo(LanguageCode.ID, "Guam"),
+            new TranslationInfo(LanguageCode.IS, "Gvam"),
             new TranslationInfo(LanguageCode.IT, "Guam"),
             new TranslationInfo(LanguageCode.JA, "グアム"),
             new TranslationInfo(LanguageCode.KA, "გუამი"),

--- a/src/Nager.Country.Translation/CountryTranslations/GuatemalaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/GuatemalaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Guatemala"),
             new TranslationInfo(LanguageCode.HY, "Գվատեմալա"),
             new TranslationInfo(LanguageCode.ID, "Guatamala"),
+            new TranslationInfo(LanguageCode.IS, "Gvatemala"),
             new TranslationInfo(LanguageCode.IT, "Guatemala"),
             new TranslationInfo(LanguageCode.JA, "グアテマラ"),
             new TranslationInfo(LanguageCode.KA, "გვატემალა"),

--- a/src/Nager.Country.Translation/CountryTranslations/GuernseyCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/GuernseyCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Guernsey"),
             new TranslationInfo(LanguageCode.HY, "Գերնսի"),
             new TranslationInfo(LanguageCode.ID, "Guernsey"),
+            new TranslationInfo(LanguageCode.IS, "Guernsey"),
             new TranslationInfo(LanguageCode.IT, "Guernsey"),
             new TranslationInfo(LanguageCode.JA, "ガーンジー"),
             new TranslationInfo(LanguageCode.KA, "გერნსი"),

--- a/src/Nager.Country.Translation/CountryTranslations/GuineaBissauCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/GuineaBissauCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Bissau-Guinea"),
             new TranslationInfo(LanguageCode.HY, "Գվինեա-Բիսսաու"),
             new TranslationInfo(LanguageCode.ID, "Guinea-Bissau"),
+            new TranslationInfo(LanguageCode.IS, "Gínea-Bissá"),
             new TranslationInfo(LanguageCode.IT, "Guinea-Bissau"),
             new TranslationInfo(LanguageCode.JA, "ギニアビサウ"),
             new TranslationInfo(LanguageCode.KA, "გვინეა-ბისაუ"),

--- a/src/Nager.Country.Translation/CountryTranslations/GuineaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/GuineaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Guinea"),
             new TranslationInfo(LanguageCode.HY, "Գվինեա"),
             new TranslationInfo(LanguageCode.ID, "Guinea"),
+            new TranslationInfo(LanguageCode.IS, "Gínea"),
             new TranslationInfo(LanguageCode.IT, "Guinea"),
             new TranslationInfo(LanguageCode.JA, "ギニア"),
             new TranslationInfo(LanguageCode.KA, "გვინეა"),

--- a/src/Nager.Country.Translation/CountryTranslations/GuyanaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/GuyanaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Guyana"),
             new TranslationInfo(LanguageCode.HY, "Գայանա"),
             new TranslationInfo(LanguageCode.ID, "Guyana"),
+            new TranslationInfo(LanguageCode.IS, "Gvæjana"),
             new TranslationInfo(LanguageCode.IT, "Guyana"),
             new TranslationInfo(LanguageCode.JA, "ガイアナ"),
             new TranslationInfo(LanguageCode.KA, "გაიანა"),

--- a/src/Nager.Country.Translation/CountryTranslations/HaitiCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/HaitiCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Haiti"),
             new TranslationInfo(LanguageCode.HY, "Հայիթի"),
             new TranslationInfo(LanguageCode.ID, "Haiti"),
+            new TranslationInfo(LanguageCode.IS, "Haítí"),
             new TranslationInfo(LanguageCode.IT, "Haiti"),
             new TranslationInfo(LanguageCode.JA, "ハイチ"),
             new TranslationInfo(LanguageCode.KA, "ჰაიტი"),

--- a/src/Nager.Country.Translation/CountryTranslations/HondurasCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/HondurasCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Honduras"),
             new TranslationInfo(LanguageCode.HY, "Հոնդուրաս"),
             new TranslationInfo(LanguageCode.ID, "Honduras"),
+            new TranslationInfo(LanguageCode.IS, "Hondúras"),
             new TranslationInfo(LanguageCode.IT, "Honduras"),
             new TranslationInfo(LanguageCode.JA, "ホンジュラス"),
             new TranslationInfo(LanguageCode.KA, "ჰონდურასი"),

--- a/src/Nager.Country.Translation/CountryTranslations/HongKongCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/HongKongCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Hong Kong"),
             new TranslationInfo(LanguageCode.HY, "Հոնկոնգի ՀՎՇ"),
             new TranslationInfo(LanguageCode.ID, "Hong Kong"),
+            new TranslationInfo(LanguageCode.IS, "Hong Kong"),
             new TranslationInfo(LanguageCode.IT, "Hong Kong"),
             new TranslationInfo(LanguageCode.JA, "香港"),
             new TranslationInfo(LanguageCode.KA, "ჰონკონგი"),

--- a/src/Nager.Country.Translation/CountryTranslations/HungaryCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/HungaryCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Magyarország"),
             new TranslationInfo(LanguageCode.HY, "Հունգարիա"),
             new TranslationInfo(LanguageCode.ID, "Hungaria"),
+            new TranslationInfo(LanguageCode.IS, "Ungverjaland"),
             new TranslationInfo(LanguageCode.IT, "Ungheria"),
             new TranslationInfo(LanguageCode.JA, "ハンガリー"),
             new TranslationInfo(LanguageCode.KA, "უნგრეთი"),

--- a/src/Nager.Country.Translation/CountryTranslations/IcelandCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/IcelandCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Izland"),
             new TranslationInfo(LanguageCode.HY, "Իսլանդիա"),
             new TranslationInfo(LanguageCode.ID, "Islandia"),
+            new TranslationInfo(LanguageCode.IS, "Ísland"),
             new TranslationInfo(LanguageCode.IT, "Islanda"),
             new TranslationInfo(LanguageCode.JA, "アイスランド"),
             new TranslationInfo(LanguageCode.KA, "ისლანდია"),

--- a/src/Nager.Country.Translation/CountryTranslations/IndiaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/IndiaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "India"),
             new TranslationInfo(LanguageCode.HY, "Հնդկաստան"),
             new TranslationInfo(LanguageCode.ID, "India"),
+            new TranslationInfo(LanguageCode.IS, "Indland"),
             new TranslationInfo(LanguageCode.IT, "India"),
             new TranslationInfo(LanguageCode.JA, "インド"),
             new TranslationInfo(LanguageCode.KA, "ინდოეთი"),

--- a/src/Nager.Country.Translation/CountryTranslations/IndonesiaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/IndonesiaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Indonézia"),
             new TranslationInfo(LanguageCode.HY, "Ինդոնեզիա"),
             new TranslationInfo(LanguageCode.ID, "Indonesia"),
+            new TranslationInfo(LanguageCode.IS, "Indónesía"),
             new TranslationInfo(LanguageCode.IT, "Indonesia"),
             new TranslationInfo(LanguageCode.JA, "インドネシア"),
             new TranslationInfo(LanguageCode.KA, "ინდონეზია"),

--- a/src/Nager.Country.Translation/CountryTranslations/IranCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/IranCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Irán"),
             new TranslationInfo(LanguageCode.HY, "Իրան"),
             new TranslationInfo(LanguageCode.ID, "Iran"),
+            new TranslationInfo(LanguageCode.IS, "Íran"),
             new TranslationInfo(LanguageCode.IT, "Iran"),
             new TranslationInfo(LanguageCode.JA, "イラン・イスラム共和国"),
             new TranslationInfo(LanguageCode.KA, "ირანი"),

--- a/src/Nager.Country.Translation/CountryTranslations/IraqCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/IraqCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Irak"),
             new TranslationInfo(LanguageCode.HY, "Իրաք"),
             new TranslationInfo(LanguageCode.ID, "Irak"),
+            new TranslationInfo(LanguageCode.IS, "Írak"),
             new TranslationInfo(LanguageCode.IT, "Iraq"),
             new TranslationInfo(LanguageCode.JA, "イラク"),
             new TranslationInfo(LanguageCode.KA, "ერაყი"),

--- a/src/Nager.Country.Translation/CountryTranslations/IrelandCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/IrelandCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Írország"),
             new TranslationInfo(LanguageCode.HY, "Իռլանդիա"),
             new TranslationInfo(LanguageCode.ID, "Irlandia"),
+            new TranslationInfo(LanguageCode.IS, "Írland"),
             new TranslationInfo(LanguageCode.IT, "Irlanda"),
             new TranslationInfo(LanguageCode.JA, "アイルランド"),
             new TranslationInfo(LanguageCode.KA, "ირლანდია"),

--- a/src/Nager.Country.Translation/CountryTranslations/IsraelCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/IsraelCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Izrael"),
             new TranslationInfo(LanguageCode.HY, "Իսրայել"),
             new TranslationInfo(LanguageCode.ID, "Israel"),
+            new TranslationInfo(LanguageCode.IS, "Ísrael"),
             new TranslationInfo(LanguageCode.IT, "Israele"),
             new TranslationInfo(LanguageCode.JA, "イスラエル"),
             new TranslationInfo(LanguageCode.KA, "ისრაელი"),

--- a/src/Nager.Country.Translation/CountryTranslations/ItalyCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/ItalyCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Olaszország"),
             new TranslationInfo(LanguageCode.HY, "Իտալիա"),
             new TranslationInfo(LanguageCode.ID, "Italia"),
+            new TranslationInfo(LanguageCode.IS, "Ítalía"),
             new TranslationInfo(LanguageCode.IT, "Italia"),
             new TranslationInfo(LanguageCode.JA, "イタリア"),
             new TranslationInfo(LanguageCode.KA, "იტალია"),

--- a/src/Nager.Country.Translation/CountryTranslations/IvoryCoastCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/IvoryCoastCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Elefántcsontpart"),
             new TranslationInfo(LanguageCode.HY, "Կոտ դ’Իվուար"),
             new TranslationInfo(LanguageCode.ID, "Pantai Gading"),
+            new TranslationInfo(LanguageCode.IS, "Fílabeinsströndin"),
             new TranslationInfo(LanguageCode.IT, "Costa d'Avorio"),
             new TranslationInfo(LanguageCode.JA, "コートジボワール"),
             new TranslationInfo(LanguageCode.KA, "კოტ-დივუარი"),

--- a/src/Nager.Country.Translation/CountryTranslations/JamaicaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/JamaicaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Jamaica"),
             new TranslationInfo(LanguageCode.HY, "Ճամայկա"),
             new TranslationInfo(LanguageCode.ID, "Jamaika"),
+            new TranslationInfo(LanguageCode.IS, "Jamaíka"),
             new TranslationInfo(LanguageCode.IT, "Giamaica"),
             new TranslationInfo(LanguageCode.JA, "ジャマイカ"),
             new TranslationInfo(LanguageCode.KA, "იამაიკა"),

--- a/src/Nager.Country.Translation/CountryTranslations/JapanCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/JapanCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Japán"),
             new TranslationInfo(LanguageCode.HY, "Ճապոնիա"),
             new TranslationInfo(LanguageCode.ID, "Jepang"),
+            new TranslationInfo(LanguageCode.IS, "Japan"),
             new TranslationInfo(LanguageCode.IT, "Giappone"),
             new TranslationInfo(LanguageCode.JA, "日本"),
             new TranslationInfo(LanguageCode.KA, "იაპონია"),

--- a/src/Nager.Country.Translation/CountryTranslations/JordanCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/JordanCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Jordánia"),
             new TranslationInfo(LanguageCode.HY, "Հորդանան"),
             new TranslationInfo(LanguageCode.ID, "Yordania"),
+            new TranslationInfo(LanguageCode.IS, "Jórdanía"),
             new TranslationInfo(LanguageCode.IT, "Giordania"),
             new TranslationInfo(LanguageCode.JA, "ヨルダン"),
             new TranslationInfo(LanguageCode.KA, "იორდანია"),

--- a/src/Nager.Country.Translation/CountryTranslations/KazakhstanCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/KazakhstanCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Kazahsztán"),
             new TranslationInfo(LanguageCode.HY, "Ղազախստան"),
             new TranslationInfo(LanguageCode.ID, "Kazakhstan"),
+            new TranslationInfo(LanguageCode.IS, "Kasakstan"),
             new TranslationInfo(LanguageCode.IT, "Kazakistan"),
             new TranslationInfo(LanguageCode.JA, "カザフスタン"),
             new TranslationInfo(LanguageCode.KA, "ყაზახეთი"),

--- a/src/Nager.Country.Translation/CountryTranslations/KenyaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/KenyaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Kenya"),
             new TranslationInfo(LanguageCode.HY, "Քենիա"),
             new TranslationInfo(LanguageCode.ID, "Kenya"),
+            new TranslationInfo(LanguageCode.IS, "Kenía"),
             new TranslationInfo(LanguageCode.IT, "Kenya"),
             new TranslationInfo(LanguageCode.JA, "ケニア"),
             new TranslationInfo(LanguageCode.KA, "კენია"),

--- a/src/Nager.Country.Translation/CountryTranslations/KiribatiCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/KiribatiCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Kiribati"),
             new TranslationInfo(LanguageCode.HY, "Կիրիբատի"),
             new TranslationInfo(LanguageCode.ID, "Kiribati"),
+            new TranslationInfo(LanguageCode.IS, "Kíribatí"),
             new TranslationInfo(LanguageCode.IT, "Kiribati"),
             new TranslationInfo(LanguageCode.JA, "キリバス"),
             new TranslationInfo(LanguageCode.KA, "კირიბატი"),

--- a/src/Nager.Country.Translation/CountryTranslations/KuwaitCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/KuwaitCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Kuvait"),
             new TranslationInfo(LanguageCode.HY, "Քուվեյթ"),
             new TranslationInfo(LanguageCode.ID, "Kuwait"),
+            new TranslationInfo(LanguageCode.IS, "Kúveit"),
             new TranslationInfo(LanguageCode.IT, "Kuwait"),
             new TranslationInfo(LanguageCode.JA, "クウェート"),
             new TranslationInfo(LanguageCode.KA, "ქუვეითი"),

--- a/src/Nager.Country.Translation/CountryTranslations/KyrgyzstanCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/KyrgyzstanCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Kirgizisztán"),
             new TranslationInfo(LanguageCode.HY, "Ղրղզստան"),
             new TranslationInfo(LanguageCode.ID, "Kyrgyzstan"),
+            new TranslationInfo(LanguageCode.IS, "Kirgistan"),
             new TranslationInfo(LanguageCode.IT, "Kirghizistan"),
             new TranslationInfo(LanguageCode.JA, "キルギス"),
             new TranslationInfo(LanguageCode.KA, "ყირგიზეთი"),

--- a/src/Nager.Country.Translation/CountryTranslations/LaosCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/LaosCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Laosz"),
             new TranslationInfo(LanguageCode.HY, "Լաոս"),
             new TranslationInfo(LanguageCode.ID, "Laos"),
+            new TranslationInfo(LanguageCode.IS, "Laos"),
             new TranslationInfo(LanguageCode.IT, "Laos"),
             new TranslationInfo(LanguageCode.JA, "ラオス人民民主共和国"),
             new TranslationInfo(LanguageCode.KA, "ლაოსი"),

--- a/src/Nager.Country.Translation/CountryTranslations/LatviaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/LatviaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Lettország"),
             new TranslationInfo(LanguageCode.HY, "Լատվիա"),
             new TranslationInfo(LanguageCode.ID, "Latvia"),
+            new TranslationInfo(LanguageCode.IS, "Lettland"),
             new TranslationInfo(LanguageCode.IT, "Lettonia"),
             new TranslationInfo(LanguageCode.JA, "ラトビア"),
             new TranslationInfo(LanguageCode.KA, "ლატვია"),

--- a/src/Nager.Country.Translation/CountryTranslations/LebanonCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/LebanonCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Libanon"),
             new TranslationInfo(LanguageCode.HY, "Լիբանան"),
             new TranslationInfo(LanguageCode.ID, "Lebanon"),
+            new TranslationInfo(LanguageCode.IS, "Líbanon"),
             new TranslationInfo(LanguageCode.IT, "Libano"),
             new TranslationInfo(LanguageCode.JA, "レバノン"),
             new TranslationInfo(LanguageCode.KA, "ლიბანი"),

--- a/src/Nager.Country.Translation/CountryTranslations/LesothoCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/LesothoCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Lesotho"),
             new TranslationInfo(LanguageCode.HY, "Լեսոտո"),
             new TranslationInfo(LanguageCode.ID, "Lesotho"),
+            new TranslationInfo(LanguageCode.IS, "Lesótó"),
             new TranslationInfo(LanguageCode.IT, "Lesotho"),
             new TranslationInfo(LanguageCode.JA, "レソト"),
             new TranslationInfo(LanguageCode.KA, "ლესოთო"),

--- a/src/Nager.Country.Translation/CountryTranslations/LiberiaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/LiberiaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Libéria"),
             new TranslationInfo(LanguageCode.HY, "Լիբերիա"),
             new TranslationInfo(LanguageCode.ID, "Liberia"),
+            new TranslationInfo(LanguageCode.IS, "Líbería"),
             new TranslationInfo(LanguageCode.IT, "Liberia"),
             new TranslationInfo(LanguageCode.JA, "リベリア"),
             new TranslationInfo(LanguageCode.KA, "ლიბერია"),

--- a/src/Nager.Country.Translation/CountryTranslations/LibyaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/LibyaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Líbia"),
             new TranslationInfo(LanguageCode.HY, "Լիբիա"),
             new TranslationInfo(LanguageCode.ID, "Libya"),
+            new TranslationInfo(LanguageCode.IS, "Líbía"),
             new TranslationInfo(LanguageCode.IT, "Libia"),
             new TranslationInfo(LanguageCode.JA, "リビア"),
             new TranslationInfo(LanguageCode.KA, "ლიბია"),

--- a/src/Nager.Country.Translation/CountryTranslations/LiechtensteinCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/LiechtensteinCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Liechtenstein"),
             new TranslationInfo(LanguageCode.HY, "Լիխտենշտեյն"),
             new TranslationInfo(LanguageCode.ID, "Liechtenstein"),
+            new TranslationInfo(LanguageCode.IS, "Liechtenstein"),
             new TranslationInfo(LanguageCode.IT, "Liechtenstein"),
             new TranslationInfo(LanguageCode.JA, "リヒテンシュタイン"),
             new TranslationInfo(LanguageCode.KA, "ლიხტენშტაინი"),

--- a/src/Nager.Country.Translation/CountryTranslations/LithuaniaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/LithuaniaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Litvánia"),
             new TranslationInfo(LanguageCode.HY, "Լիտվա"),
             new TranslationInfo(LanguageCode.ID, "Lithuania"),
+            new TranslationInfo(LanguageCode.IS, "Litháen"),
             new TranslationInfo(LanguageCode.IT, "Lituania"),
             new TranslationInfo(LanguageCode.JA, "リトアニア"),
             new TranslationInfo(LanguageCode.KA, "ლიტვა"),

--- a/src/Nager.Country.Translation/CountryTranslations/LuxembourgCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/LuxembourgCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Luxemburg"),
             new TranslationInfo(LanguageCode.HY, "Լյուքսեմբուրգ"),
             new TranslationInfo(LanguageCode.ID, "Luxemburg"),
+            new TranslationInfo(LanguageCode.IS, "Lúxemborg"),
             new TranslationInfo(LanguageCode.IT, "Lussemburgo"),
             new TranslationInfo(LanguageCode.JA, "ルクセンブルク"),
             new TranslationInfo(LanguageCode.KA, "ლუქსემბურგი"),

--- a/src/Nager.Country.Translation/CountryTranslations/MacauCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/MacauCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Makao"),
             new TranslationInfo(LanguageCode.HY, "Չինաստանի Մակաո ՀՎՇ"),
             new TranslationInfo(LanguageCode.ID, "Makau"),
+            new TranslationInfo(LanguageCode.IS, "Makaó"),
             new TranslationInfo(LanguageCode.IT, "Macao"),
             new TranslationInfo(LanguageCode.JA, "マカオ"),
             new TranslationInfo(LanguageCode.KA, "მაკაო"),

--- a/src/Nager.Country.Translation/CountryTranslations/MadagascarCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/MadagascarCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Madagaszkár"),
             new TranslationInfo(LanguageCode.HY, "Մադագասկար"),
             new TranslationInfo(LanguageCode.ID, "Madagaskar"),
+            new TranslationInfo(LanguageCode.IS, "Madagaskar"),
             new TranslationInfo(LanguageCode.IT, "Madagascar"),
             new TranslationInfo(LanguageCode.JA, "マダガスカル"),
             new TranslationInfo(LanguageCode.KA, "მადაგასკარი"),

--- a/src/Nager.Country.Translation/CountryTranslations/MalawiCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/MalawiCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Malawi"),
             new TranslationInfo(LanguageCode.HY, "Մալավի"),
             new TranslationInfo(LanguageCode.ID, "Malawi"),
+            new TranslationInfo(LanguageCode.IS, "Malaví"),
             new TranslationInfo(LanguageCode.IT, "Malawi"),
             new TranslationInfo(LanguageCode.JA, "マラウイ"),
             new TranslationInfo(LanguageCode.KA, "მალავი"),

--- a/src/Nager.Country.Translation/CountryTranslations/MalaysiaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/MalaysiaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Malajzia"),
             new TranslationInfo(LanguageCode.HY, "Մալայզիա"),
             new TranslationInfo(LanguageCode.ID, "Malaysia"),
+            new TranslationInfo(LanguageCode.IS, "Malasía"),
             new TranslationInfo(LanguageCode.IT, "Malesia"),
             new TranslationInfo(LanguageCode.JA, "マレーシア"),
             new TranslationInfo(LanguageCode.KA, "მალაიზია"),

--- a/src/Nager.Country.Translation/CountryTranslations/MaldivesCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/MaldivesCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Maldív-szigetek"),
             new TranslationInfo(LanguageCode.HY, "Մալդիվներ"),
             new TranslationInfo(LanguageCode.ID, "Maldives"),
+            new TranslationInfo(LanguageCode.IS, "Maldívur"),
             new TranslationInfo(LanguageCode.IT, "Maldive"),
             new TranslationInfo(LanguageCode.JA, "モルディブ"),
             new TranslationInfo(LanguageCode.KA, "მალდივები"),

--- a/src/Nager.Country.Translation/CountryTranslations/MaliCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/MaliCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Mali"),
             new TranslationInfo(LanguageCode.HY, "Մալի"),
             new TranslationInfo(LanguageCode.ID, "Mali"),
+            new TranslationInfo(LanguageCode.IS, "Malí"),
             new TranslationInfo(LanguageCode.IT, "Mali"),
             new TranslationInfo(LanguageCode.JA, "マリ"),
             new TranslationInfo(LanguageCode.KA, "მალი"),

--- a/src/Nager.Country.Translation/CountryTranslations/MaltaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/MaltaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Málta"),
             new TranslationInfo(LanguageCode.HY, "Մալթա"),
             new TranslationInfo(LanguageCode.ID, "Malta"),
+            new TranslationInfo(LanguageCode.IS, "Malta"),
             new TranslationInfo(LanguageCode.IT, "Malta"),
             new TranslationInfo(LanguageCode.JA, "マルタ"),
             new TranslationInfo(LanguageCode.KA, "მალტა"),

--- a/src/Nager.Country.Translation/CountryTranslations/MarshallIslandsCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/MarshallIslandsCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Marshall-szigetek"),
             new TranslationInfo(LanguageCode.HY, "Մարշալյան կղզիներ"),
             new TranslationInfo(LanguageCode.ID, "Kepulauan Marshall"),
+            new TranslationInfo(LanguageCode.IS, "Marshall-eyjar"),
             new TranslationInfo(LanguageCode.IT, "Isole Marshall"),
             new TranslationInfo(LanguageCode.JA, "マーシャル諸島"),
             new TranslationInfo(LanguageCode.KA, "მარშალის კუნძულები"),

--- a/src/Nager.Country.Translation/CountryTranslations/MartiniqueCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/MartiniqueCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Martinique"),
             new TranslationInfo(LanguageCode.HY, "Մարտինիկա"),
             new TranslationInfo(LanguageCode.ID, "Martinik"),
+            new TranslationInfo(LanguageCode.IS, "Martiník"),
             new TranslationInfo(LanguageCode.IT, "Martinica"),
             new TranslationInfo(LanguageCode.JA, "マルティニーク"),
             new TranslationInfo(LanguageCode.KA, "მარტინიკა"),

--- a/src/Nager.Country.Translation/CountryTranslations/MauritaniaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/MauritaniaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Mauritánia"),
             new TranslationInfo(LanguageCode.HY, "Մավրիտանիա"),
             new TranslationInfo(LanguageCode.ID, "Mauritania"),
+            new TranslationInfo(LanguageCode.IS, "Máritanía"),
             new TranslationInfo(LanguageCode.IT, "Mauritania"),
             new TranslationInfo(LanguageCode.JA, "モーリタニア"),
             new TranslationInfo(LanguageCode.KA, "მავრიტანია"),

--- a/src/Nager.Country.Translation/CountryTranslations/MauritiusCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/MauritiusCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Mauritius"),
             new TranslationInfo(LanguageCode.HY, "Մավրիկիոս"),
             new TranslationInfo(LanguageCode.ID, "Mauritius"),
+            new TranslationInfo(LanguageCode.IS, "Máritíus"),
             new TranslationInfo(LanguageCode.IT, "Mauritius"),
             new TranslationInfo(LanguageCode.JA, "モーリシャス"),
             new TranslationInfo(LanguageCode.KA, "მავრიკი"),

--- a/src/Nager.Country.Translation/CountryTranslations/MayotteCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/MayotteCountryTranslation.cs
@@ -30,6 +30,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HY, "Մայոտ"),
             new TranslationInfo(LanguageCode.ID, "Mayotte"),
             new TranslationInfo(LanguageCode.IT, "Mayotte"),
+            new TranslationInfo(LanguageCode.IS, "Mayotte"),
             new TranslationInfo(LanguageCode.JA, "マヨット"),
             new TranslationInfo(LanguageCode.KA, "მაიოტა"),
             new TranslationInfo(LanguageCode.KK, "Майотта"),

--- a/src/Nager.Country.Translation/CountryTranslations/MexicoCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/MexicoCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Mexikó"),
             new TranslationInfo(LanguageCode.HY, "Մեքսիկա"),
             new TranslationInfo(LanguageCode.ID, "Meksiko"),
+            new TranslationInfo(LanguageCode.IS, "Mexíkó"),
             new TranslationInfo(LanguageCode.IT, "Messico"),
             new TranslationInfo(LanguageCode.JA, "メキシコ"),
             new TranslationInfo(LanguageCode.KA, "მექსიკა"),

--- a/src/Nager.Country.Translation/CountryTranslations/MicronesiaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/MicronesiaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Mikronéziai Szövetségi Államok"),
             new TranslationInfo(LanguageCode.HY, "Միկրոնեզիա"),
             new TranslationInfo(LanguageCode.ID, "Federasi Mikronesia"),
+            new TranslationInfo(LanguageCode.IS, "Mikrónesía"),
             new TranslationInfo(LanguageCode.IT, "Stati Federati di Micronesia"),
             new TranslationInfo(LanguageCode.JA, "ミクロネシア連邦"),
             new TranslationInfo(LanguageCode.KA, "მიკრონეზია"),

--- a/src/Nager.Country.Translation/CountryTranslations/MoldovaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/MoldovaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Moldova"),
             new TranslationInfo(LanguageCode.HY, "Մոլդովա"),
             new TranslationInfo(LanguageCode.ID, "Moldova"),
+            new TranslationInfo(LanguageCode.IS, "Moldóva"),
             new TranslationInfo(LanguageCode.IT, "Moldavia"),
             new TranslationInfo(LanguageCode.JA, "モルドバ共和国"),
             new TranslationInfo(LanguageCode.KA, "მოლდოვა"),

--- a/src/Nager.Country.Translation/CountryTranslations/MonacoCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/MonacoCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Monaco"),
             new TranslationInfo(LanguageCode.HY, "Մոնակո"),
             new TranslationInfo(LanguageCode.ID, "Monako"),
+            new TranslationInfo(LanguageCode.IS, "Mónakó"),
             new TranslationInfo(LanguageCode.IT, "Monaco"),
             new TranslationInfo(LanguageCode.JA, "モナコ"),
             new TranslationInfo(LanguageCode.KA, "მონაკო"),

--- a/src/Nager.Country.Translation/CountryTranslations/MongoliaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/MongoliaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Mongólia"),
             new TranslationInfo(LanguageCode.HY, "Մոնղոլիա"),
             new TranslationInfo(LanguageCode.ID, "Mongolia"),
+            new TranslationInfo(LanguageCode.IS, "Mongólía"),
             new TranslationInfo(LanguageCode.IT, "Mongolia"),
             new TranslationInfo(LanguageCode.JA, "モンゴル"),
             new TranslationInfo(LanguageCode.KA, "მონღოლეთი"),

--- a/src/Nager.Country.Translation/CountryTranslations/MontenegroCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/MontenegroCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Montenegró"),
             new TranslationInfo(LanguageCode.HY, "Չեռնոգորիա"),
             new TranslationInfo(LanguageCode.ID, "Montenegro"),
+            new TranslationInfo(LanguageCode.IS, "Svartfjallaland"),
             new TranslationInfo(LanguageCode.IT, "Montenegro"),
             new TranslationInfo(LanguageCode.JA, "モンテネグロ"),
             new TranslationInfo(LanguageCode.KA, "მონტენეგრო"),

--- a/src/Nager.Country.Translation/CountryTranslations/MontserratCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/MontserratCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Montserrat"),
             new TranslationInfo(LanguageCode.HY, "Մոնսեռատ"),
             new TranslationInfo(LanguageCode.ID, "Montserrat"),
+            new TranslationInfo(LanguageCode.IS, "Montserrat"),
             new TranslationInfo(LanguageCode.IT, "Montserrat"),
             new TranslationInfo(LanguageCode.JA, "モントセラト"),
             new TranslationInfo(LanguageCode.KA, "მონსერატი"),

--- a/src/Nager.Country.Translation/CountryTranslations/MoroccoCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/MoroccoCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Marokkó"),
             new TranslationInfo(LanguageCode.HY, "Մարոկկո"),
             new TranslationInfo(LanguageCode.ID, "Moroko"),
+            new TranslationInfo(LanguageCode.IS, "Marokkó"),
             new TranslationInfo(LanguageCode.IT, "Marocco"),
             new TranslationInfo(LanguageCode.JA, "モロッコ"),
             new TranslationInfo(LanguageCode.KA, "მაროკო"),

--- a/src/Nager.Country.Translation/CountryTranslations/MozambiqueCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/MozambiqueCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Mozambik"),
             new TranslationInfo(LanguageCode.HY, "Մոզամբիկ"),
             new TranslationInfo(LanguageCode.ID, "Mozambik"),
+            new TranslationInfo(LanguageCode.IS, "Mósambík"),
             new TranslationInfo(LanguageCode.IT, "Mozambico"),
             new TranslationInfo(LanguageCode.JA, "モザンビーク"),
             new TranslationInfo(LanguageCode.KA, "მოზამბიკი"),

--- a/src/Nager.Country.Translation/CountryTranslations/MyanmarCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/MyanmarCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Mianmar"),
             new TranslationInfo(LanguageCode.HY, "Մյանմա (Բիրմա)"),
             new TranslationInfo(LanguageCode.ID, "Myanmar"),
+            new TranslationInfo(LanguageCode.IS, "Myanmar"),
             new TranslationInfo(LanguageCode.IT, "Birmania  Myanmar"),
             new TranslationInfo(LanguageCode.JA, "ミャンマー"),
             new TranslationInfo(LanguageCode.KA, "მიანმარი (ბირმა)"),

--- a/src/Nager.Country.Translation/CountryTranslations/NamibiaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/NamibiaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Namíbia"),
             new TranslationInfo(LanguageCode.HY, "Նամիբիա"),
             new TranslationInfo(LanguageCode.ID, "Namibia"),
+            new TranslationInfo(LanguageCode.IS, "Namibía"),
             new TranslationInfo(LanguageCode.IT, "Namibia"),
             new TranslationInfo(LanguageCode.JA, "ナミビア"),
             new TranslationInfo(LanguageCode.KA, "ნამიბია"),

--- a/src/Nager.Country.Translation/CountryTranslations/NauruCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/NauruCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Nauru"),
             new TranslationInfo(LanguageCode.HY, "Նաուրու"),
             new TranslationInfo(LanguageCode.ID, "Nauru"),
+            new TranslationInfo(LanguageCode.IS, "Naúrú"),
             new TranslationInfo(LanguageCode.IT, "Nauru"),
             new TranslationInfo(LanguageCode.JA, "ナウル"),
             new TranslationInfo(LanguageCode.KA, "ნაურუ"),

--- a/src/Nager.Country.Translation/CountryTranslations/NepalCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/NepalCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Nepál"),
             new TranslationInfo(LanguageCode.HY, "Նեպալ"),
             new TranslationInfo(LanguageCode.ID, "Nepal"),
+            new TranslationInfo(LanguageCode.IS, "Nepal"),
             new TranslationInfo(LanguageCode.IT, "Nepal"),
             new TranslationInfo(LanguageCode.JA, "ネパール"),
             new TranslationInfo(LanguageCode.KA, "ნეპალი"),

--- a/src/Nager.Country.Translation/CountryTranslations/NetherlandsCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/NetherlandsCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Hollandia"),
             new TranslationInfo(LanguageCode.HY, "Նիդեռլանդներ"),
             new TranslationInfo(LanguageCode.ID, "Belanda"),
+            new TranslationInfo(LanguageCode.IS, "Holland"),
             new TranslationInfo(LanguageCode.IT, "Paesi Bassi"),
             new TranslationInfo(LanguageCode.JA, "オランダ"),
             new TranslationInfo(LanguageCode.KA, "ნიდერლანდები"),

--- a/src/Nager.Country.Translation/CountryTranslations/NewCaledoniaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/NewCaledoniaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Új-Kaledónia"),
             new TranslationInfo(LanguageCode.HY, "Նոր Կալեդոնիա"),
             new TranslationInfo(LanguageCode.ID, "Kaledonia Baru"),
+            new TranslationInfo(LanguageCode.IS, "Nýja-Kaledónía"),
             new TranslationInfo(LanguageCode.IT, "Nuova Caledonia"),
             new TranslationInfo(LanguageCode.JA, "ニューカレドニア"),
             new TranslationInfo(LanguageCode.KA, "ახალი კალედონია"),

--- a/src/Nager.Country.Translation/CountryTranslations/NewZealandCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/NewZealandCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Új-Zéland"),
             new TranslationInfo(LanguageCode.HY, "Նոր Զելանդիա"),
             new TranslationInfo(LanguageCode.ID, "Selandia Baru"),
+            new TranslationInfo(LanguageCode.IS, "Nýja-Sjáland"),
             new TranslationInfo(LanguageCode.IT, "Nuova Zelanda"),
             new TranslationInfo(LanguageCode.JA, "ニュージーランド"),
             new TranslationInfo(LanguageCode.KA, "ახალი ზელანდია"),

--- a/src/Nager.Country.Translation/CountryTranslations/NicaraguaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/NicaraguaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Nicaragua"),
             new TranslationInfo(LanguageCode.HY, "Նիկարագուա"),
             new TranslationInfo(LanguageCode.ID, "Nikaragua"),
+            new TranslationInfo(LanguageCode.IS, "Níkaragva"),
             new TranslationInfo(LanguageCode.IT, "Nicaragua"),
             new TranslationInfo(LanguageCode.JA, "ニカラグア"),
             new TranslationInfo(LanguageCode.KA, "ნიკარაგუა"),

--- a/src/Nager.Country.Translation/CountryTranslations/NigerCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/NigerCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Niger"),
             new TranslationInfo(LanguageCode.HY, "Նիգեր"),
             new TranslationInfo(LanguageCode.ID, "Niger"),
+            new TranslationInfo(LanguageCode.IS, "Níger"),
             new TranslationInfo(LanguageCode.IT, "Niger"),
             new TranslationInfo(LanguageCode.JA, "ニジェール"),
             new TranslationInfo(LanguageCode.KA, "ნიგერი"),

--- a/src/Nager.Country.Translation/CountryTranslations/NigeriaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/NigeriaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Nigéria"),
             new TranslationInfo(LanguageCode.HY, "Նիգերիա"),
             new TranslationInfo(LanguageCode.ID, "Nigeria"),
+            new TranslationInfo(LanguageCode.IS, "Nígería"),
             new TranslationInfo(LanguageCode.IT, "Nigeria"),
             new TranslationInfo(LanguageCode.JA, "ナイジェリア"),
             new TranslationInfo(LanguageCode.KA, "ნიგერია"),

--- a/src/Nager.Country.Translation/CountryTranslations/NiueCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/NiueCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Niue"),
             new TranslationInfo(LanguageCode.HY, "Նիուե"),
             new TranslationInfo(LanguageCode.ID, "Niue"),
+            new TranslationInfo(LanguageCode.IS, "Niue"),
             new TranslationInfo(LanguageCode.IT, "Niue"),
             new TranslationInfo(LanguageCode.JA, "ニウエ"),
             new TranslationInfo(LanguageCode.KA, "ნიუე"),

--- a/src/Nager.Country.Translation/CountryTranslations/NorfolkIslandCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/NorfolkIslandCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Norfolk-sziget"),
             new TranslationInfo(LanguageCode.HY, "Նորֆոլկ կղզի"),
             new TranslationInfo(LanguageCode.ID, "Kepulauan Norfolk"),
+            new TranslationInfo(LanguageCode.IS, "Norfolkeyja"),
             new TranslationInfo(LanguageCode.IT, "Isola Norfolk"),
             new TranslationInfo(LanguageCode.JA, "ノーフォーク島"),
             new TranslationInfo(LanguageCode.KA, "ნორფოლკის კუნძული"),

--- a/src/Nager.Country.Translation/CountryTranslations/NorthKoreaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/NorthKoreaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Észak-Korea"),
             new TranslationInfo(LanguageCode.HY, "Հյուսիսային Կորեա"),
             new TranslationInfo(LanguageCode.ID, "Korea Utara"),
+            new TranslationInfo(LanguageCode.IS, "Norður-Kórea"),
             new TranslationInfo(LanguageCode.IT, "Corea del Nord"),
             new TranslationInfo(LanguageCode.JA, "朝鮮民主主義人民共和国"),
             new TranslationInfo(LanguageCode.KA, "ჩრდილოეთ კორეა"),

--- a/src/Nager.Country.Translation/CountryTranslations/NorthMacedoniaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/NorthMacedoniaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Észak-Macedónia"),
             new TranslationInfo(LanguageCode.HY, "Հյուսիսային Մակեդոնիա"),
             new TranslationInfo(LanguageCode.ID, "Makedonia Utara"),
+            new TranslationInfo(LanguageCode.IS, "Norður-Makedónía"),
             new TranslationInfo(LanguageCode.IT, "Macedonia del Nord"),
             new TranslationInfo(LanguageCode.JA, "北マケドニア"),
             new TranslationInfo(LanguageCode.KA, "ჩრდილოეთ მაკედონია"),

--- a/src/Nager.Country.Translation/CountryTranslations/NorthernMarianaIslandsCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/NorthernMarianaIslandsCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Északi-Mariana-szigetek"),
             new TranslationInfo(LanguageCode.HY, "Հյուսիսային Մարիանյան կղզիներ"),
             new TranslationInfo(LanguageCode.ID, "Kepulauan Mariana Utara"),
+            new TranslationInfo(LanguageCode.IS, "Norður-Maríanaeyjar"),
             new TranslationInfo(LanguageCode.IT, "Isole Marianne Settentrionali"),
             new TranslationInfo(LanguageCode.JA, "北マリアナ諸島"),
             new TranslationInfo(LanguageCode.KA, "ჩრდილოეთ მარიანას კუნძულები"),

--- a/src/Nager.Country.Translation/CountryTranslations/NorwayCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/NorwayCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Norvégia"),
             new TranslationInfo(LanguageCode.HY, "Նորվեգիա"),
             new TranslationInfo(LanguageCode.ID, "Norwegia"),
+            new TranslationInfo(LanguageCode.IS, "Noregur"),
             new TranslationInfo(LanguageCode.IT, "Norvegia"),
             new TranslationInfo(LanguageCode.JA, "ノルウェー"),
             new TranslationInfo(LanguageCode.KA, "ნორვეგია"),

--- a/src/Nager.Country.Translation/CountryTranslations/OmanCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/OmanCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Omán"),
             new TranslationInfo(LanguageCode.HY, "Օման"),
             new TranslationInfo(LanguageCode.ID, "Oman"),
+            new TranslationInfo(LanguageCode.IS, "Óman"),
             new TranslationInfo(LanguageCode.IT, "Oman"),
             new TranslationInfo(LanguageCode.JA, "オマーン"),
             new TranslationInfo(LanguageCode.KA, "ომანი"),

--- a/src/Nager.Country.Translation/CountryTranslations/PakistanCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/PakistanCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Pakisztán"),
             new TranslationInfo(LanguageCode.HY, "Պակիստան"),
             new TranslationInfo(LanguageCode.ID, "Pakistan"),
+            new TranslationInfo(LanguageCode.IS, "Pakistan"),
             new TranslationInfo(LanguageCode.IT, "Pakistan"),
             new TranslationInfo(LanguageCode.JA, "パキスタン"),
             new TranslationInfo(LanguageCode.KA, "პაკისტანი"),

--- a/src/Nager.Country.Translation/CountryTranslations/PalauCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/PalauCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Palau"),
             new TranslationInfo(LanguageCode.HY, "Պալաու"),
             new TranslationInfo(LanguageCode.ID, "Palau"),
+            new TranslationInfo(LanguageCode.IS, "Palaú"),
             new TranslationInfo(LanguageCode.IT, "Palau"),
             new TranslationInfo(LanguageCode.JA, "パラオ"),
             new TranslationInfo(LanguageCode.KA, "პალაუ"),

--- a/src/Nager.Country.Translation/CountryTranslations/PalestineCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/PalestineCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Palesztina"),
             new TranslationInfo(LanguageCode.HY, "Պաղեստինյան տարածքներ"),
             new TranslationInfo(LanguageCode.ID, "Palestina"),
+            new TranslationInfo(LanguageCode.IS, "Palestína"),
             new TranslationInfo(LanguageCode.IT, "Stato di Palestina"),
             new TranslationInfo(LanguageCode.JA, "パレスチナ"),
             new TranslationInfo(LanguageCode.KA, "პალესტინის ტერიტორიები"),

--- a/src/Nager.Country.Translation/CountryTranslations/PanamaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/PanamaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Panama"),
             new TranslationInfo(LanguageCode.HY, "Պանամա"),
             new TranslationInfo(LanguageCode.ID, "Panama"),
+            new TranslationInfo(LanguageCode.IS, "Panama"),
             new TranslationInfo(LanguageCode.IT, "Panamá"),
             new TranslationInfo(LanguageCode.JA, "パナマ"),
             new TranslationInfo(LanguageCode.KA, "პანამა"),

--- a/src/Nager.Country.Translation/CountryTranslations/PapuaNewGuineaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/PapuaNewGuineaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Pápua Új-Guinea"),
             new TranslationInfo(LanguageCode.HY, "Պապուա Նոր Գվինեա"),
             new TranslationInfo(LanguageCode.ID, "Papua Nugini"),
+            new TranslationInfo(LanguageCode.IS, "Papúa Nýja-Gínea"),
             new TranslationInfo(LanguageCode.IT, "Papua Nuova Guinea"),
             new TranslationInfo(LanguageCode.JA, "パプアニューギニア"),
             new TranslationInfo(LanguageCode.KA, "პაპუა-ახალი გვინეა"),

--- a/src/Nager.Country.Translation/CountryTranslations/ParaguayCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/ParaguayCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Paraguay"),
             new TranslationInfo(LanguageCode.HY, "Պարագվայ"),
             new TranslationInfo(LanguageCode.ID, "Paraguay"),
+            new TranslationInfo(LanguageCode.IS, "Paragvæ"),
             new TranslationInfo(LanguageCode.IT, "Paraguay"),
             new TranslationInfo(LanguageCode.JA, "パラグアイ"),
             new TranslationInfo(LanguageCode.KA, "პარაგვაი"),

--- a/src/Nager.Country.Translation/CountryTranslations/PeruCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/PeruCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Peru"),
             new TranslationInfo(LanguageCode.HY, "Պերու"),
             new TranslationInfo(LanguageCode.ID, "Peru"),
+            new TranslationInfo(LanguageCode.IS, "Perú"),
             new TranslationInfo(LanguageCode.IT, "Perù"),
             new TranslationInfo(LanguageCode.JA, "ペルー"),
             new TranslationInfo(LanguageCode.KA, "პერუ"),

--- a/src/Nager.Country.Translation/CountryTranslations/PhilippinesCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/PhilippinesCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Fülöp-szigetek"),
             new TranslationInfo(LanguageCode.HY, "Ֆիլիպիններ"),
             new TranslationInfo(LanguageCode.ID, "Filipina"),
+            new TranslationInfo(LanguageCode.IS, "Filippseyjar"),
             new TranslationInfo(LanguageCode.IT, "Filippine"),
             new TranslationInfo(LanguageCode.JA, "フィリピン"),
             new TranslationInfo(LanguageCode.KA, "ფილიპინები"),

--- a/src/Nager.Country.Translation/CountryTranslations/PitcairnIslandsCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/PitcairnIslandsCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Pitcairn-szigetek"),
             new TranslationInfo(LanguageCode.HY, "Պիտկեռն կղզիներ"),
             new TranslationInfo(LanguageCode.ID, "Pitcairn"),
+            new TranslationInfo(LanguageCode.IS, "Pitcairn"),
             new TranslationInfo(LanguageCode.IT, "Isole Pitcairn"),
             new TranslationInfo(LanguageCode.JA, "ピトケアン"),
             new TranslationInfo(LanguageCode.KA, "პიტკერნის კუნძულები"),

--- a/src/Nager.Country.Translation/CountryTranslations/PolandCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/PolandCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Lengyelország"),
             new TranslationInfo(LanguageCode.HY, "Լեհաստան"),
             new TranslationInfo(LanguageCode.ID, "Polandia"),
+            new TranslationInfo(LanguageCode.IS, "Pólland"),
             new TranslationInfo(LanguageCode.IT, "Polonia"),
             new TranslationInfo(LanguageCode.JA, "ポーランド"),
             new TranslationInfo(LanguageCode.KA, "პოლონეთი"),

--- a/src/Nager.Country.Translation/CountryTranslations/PortugalCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/PortugalCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Portugália"),
             new TranslationInfo(LanguageCode.HY, "Պորտուգալիա"),
             new TranslationInfo(LanguageCode.ID, "Portugal"),
+            new TranslationInfo(LanguageCode.IS, "Portúgal"),
             new TranslationInfo(LanguageCode.IT, "Portogallo"),
             new TranslationInfo(LanguageCode.JA, "ポルトガル"),
             new TranslationInfo(LanguageCode.KA, "პორტუგალია"),

--- a/src/Nager.Country.Translation/CountryTranslations/PuertoRicoCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/PuertoRicoCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Puerto Rico"),
             new TranslationInfo(LanguageCode.HY, "Պուերտո Ռիկո"),
             new TranslationInfo(LanguageCode.ID, "Puerto Riko"),
+            new TranslationInfo(LanguageCode.IS, "Púertó Ríkó"),
             new TranslationInfo(LanguageCode.IT, "Porto Rico"),
             new TranslationInfo(LanguageCode.JA, "プエルトリコ"),
             new TranslationInfo(LanguageCode.KA, "პუერტო-რიკო"),

--- a/src/Nager.Country.Translation/CountryTranslations/QatarCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/QatarCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Katar"),
             new TranslationInfo(LanguageCode.HY, "Կատար"),
             new TranslationInfo(LanguageCode.ID, "Qatar"),
+            new TranslationInfo(LanguageCode.IS, "Katar"),
             new TranslationInfo(LanguageCode.IT, "Qatar"),
             new TranslationInfo(LanguageCode.JA, "カタール"),
             new TranslationInfo(LanguageCode.KA, "კატარი"),

--- a/src/Nager.Country.Translation/CountryTranslations/RepublicOfTheCongoCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/RepublicOfTheCongoCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Kongói Köztársaság"),
             new TranslationInfo(LanguageCode.HY, "Կոնգո - Բրազավիլ"),
             new TranslationInfo(LanguageCode.ID, "Kongo"),
+            new TranslationInfo(LanguageCode.IS, "Kongó"),
             new TranslationInfo(LanguageCode.IT, "Repubblica del Congo"),
             new TranslationInfo(LanguageCode.JA, "コンゴ共和国"),
             new TranslationInfo(LanguageCode.KA, "კონგო - ბრაზავილი"),

--- a/src/Nager.Country.Translation/CountryTranslations/ReunionCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/ReunionCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Réunion"),
             new TranslationInfo(LanguageCode.HY, "Ռեյունիոն"),
             new TranslationInfo(LanguageCode.ID, "Reunion"),
+            new TranslationInfo(LanguageCode.IS, "Réunion"),
             new TranslationInfo(LanguageCode.IT, "Réunion"),
             new TranslationInfo(LanguageCode.JA, "レユニオン"),
             new TranslationInfo(LanguageCode.KA, "რეუნიონი"),

--- a/src/Nager.Country.Translation/CountryTranslations/RomaniaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/RomaniaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Románia"),
             new TranslationInfo(LanguageCode.HY, "Ռումինիա"),
             new TranslationInfo(LanguageCode.ID, "Rumania"),
+            new TranslationInfo(LanguageCode.IS, "Rúmenía"),
             new TranslationInfo(LanguageCode.IT, "Romania"),
             new TranslationInfo(LanguageCode.JA, "ルーマニア"),
             new TranslationInfo(LanguageCode.KA, "რუმინეთი"),

--- a/src/Nager.Country.Translation/CountryTranslations/RussiaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/RussiaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Oroszország"),
             new TranslationInfo(LanguageCode.HY, "Ռուսաստան"),
             new TranslationInfo(LanguageCode.ID, "Rusia"),
+            new TranslationInfo(LanguageCode.IS, "Rússland"),
             new TranslationInfo(LanguageCode.IT, "Russia"),
             new TranslationInfo(LanguageCode.JA, "ロシア連邦"),
             new TranslationInfo(LanguageCode.KA, "რუსეთი"),

--- a/src/Nager.Country.Translation/CountryTranslations/RwandaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/RwandaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Ruanda"),
             new TranslationInfo(LanguageCode.HY, "Ռուանդա"),
             new TranslationInfo(LanguageCode.ID, "Rwanda"),
+            new TranslationInfo(LanguageCode.IS, "Rúanda"),
             new TranslationInfo(LanguageCode.IT, "Ruanda"),
             new TranslationInfo(LanguageCode.JA, "ルワンダ"),
             new TranslationInfo(LanguageCode.KA, "რუანდა"),

--- a/src/Nager.Country.Translation/CountryTranslations/SaintBarthelemyCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SaintBarthelemyCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Saint Barthélemy"),
             new TranslationInfo(LanguageCode.HY, "Սեն Բարտելմի"),
             new TranslationInfo(LanguageCode.ID, "Saint Barthélemy"),
+            new TranslationInfo(LanguageCode.IS, "Saint Barthélemy"),
             new TranslationInfo(LanguageCode.IT, "Saint-Barthélemy"),
             new TranslationInfo(LanguageCode.JA, "サン・バルテルミー"),
             new TranslationInfo(LanguageCode.KA, "სენ-ბართელმი"),

--- a/src/Nager.Country.Translation/CountryTranslations/SaintHelenaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SaintHelenaCountryTranslation.cs
@@ -12,6 +12,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.FR, "Sainte-Hélène"),
             new TranslationInfo(LanguageCode.ES, "Santa Elena"),
             new TranslationInfo(LanguageCode.EN, "Saint Helena"),
+            new TranslationInfo(LanguageCode.IS, "Sankti Helena"),
             new TranslationInfo(LanguageCode.NL, "Saint Helena"),
             new TranslationInfo(LanguageCode.RU, "Острова Святой Елены, Вознесения и Тристан-да-Кунья"),
 			new TranslationInfo(LanguageCode.KO, "세인트헬레나"),

--- a/src/Nager.Country.Translation/CountryTranslations/SaintKittsAndNevisCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SaintKittsAndNevisCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Saint Kitts és Nevis"),
             new TranslationInfo(LanguageCode.HY, "Սենտ Քիտս և Նևիս"),
             new TranslationInfo(LanguageCode.ID, "Saint Kitts dan Nevis"),
+            new TranslationInfo(LanguageCode.IS, "Sankti Kitts og Nevis"),
             new TranslationInfo(LanguageCode.IT, "Saint Kitts e Nevis"),
             new TranslationInfo(LanguageCode.JA, "セントクリストファー・ネイビス"),
             new TranslationInfo(LanguageCode.KA, "სენტ-კიტსი და ნევისი"),

--- a/src/Nager.Country.Translation/CountryTranslations/SaintLuciaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SaintLuciaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Saint Lucia"),
             new TranslationInfo(LanguageCode.HY, "Սենթ Լյուսիա"),
             new TranslationInfo(LanguageCode.ID, "Saint Lucia"),
+            new TranslationInfo(LanguageCode.IS, "Sankti Lúsía"),
             new TranslationInfo(LanguageCode.IT, "Santa Lucia"),
             new TranslationInfo(LanguageCode.JA, "セントルシア"),
             new TranslationInfo(LanguageCode.KA, "სენტ-ლუსია"),

--- a/src/Nager.Country.Translation/CountryTranslations/SaintMartinCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SaintMartinCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Szent Márton-sziget (francia rész)"),
             new TranslationInfo(LanguageCode.HY, "Սեն Մարտեն"),
             new TranslationInfo(LanguageCode.ID, "Saint Martin (French part)"),
+            new TranslationInfo(LanguageCode.IS, "Sankti Martin"),
             new TranslationInfo(LanguageCode.IT, "Saint-Martin"),
             new TranslationInfo(LanguageCode.JA, "サン・マルタン（フランス領）"),
             new TranslationInfo(LanguageCode.KA, "სენ-მარტენი"),

--- a/src/Nager.Country.Translation/CountryTranslations/SaintPierreAndMiquelonCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SaintPierreAndMiquelonCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Saint Pierre and Miquelon"),
             new TranslationInfo(LanguageCode.HY, "Սեն Պիեռ և Միքելոն"),
             new TranslationInfo(LanguageCode.ID, "Saint Pierre dan Miquelon"),
+            new TranslationInfo(LanguageCode.IS, "Sankti Pierre og Miquelon"),
             new TranslationInfo(LanguageCode.IT, "Saint Pierre e Miquelon"),
             new TranslationInfo(LanguageCode.JA, "サンピエール島・ミクロン島"),
             new TranslationInfo(LanguageCode.KA, "სენ-პიერი და მიკელონი"),

--- a/src/Nager.Country.Translation/CountryTranslations/SaintVincentAndTheGrenadinesCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SaintVincentAndTheGrenadinesCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Saint Vincent és a Grenadine-szigetek"),
             new TranslationInfo(LanguageCode.HY, "Սենթ Վինսենթ և Գրենադիններ"),
             new TranslationInfo(LanguageCode.ID, "Saint Vincent dan the Grenadines"),
+            new TranslationInfo(LanguageCode.IS, "Sankti Vinsent og Grenadínur"),
             new TranslationInfo(LanguageCode.IT, "Saint Vincent e Grenadine"),
             new TranslationInfo(LanguageCode.JA, "セントビンセントおよびグレナディーン諸島"),
             new TranslationInfo(LanguageCode.KA, "სენტ-ვინსენტი და გრენადინები"),

--- a/src/Nager.Country.Translation/CountryTranslations/SamoaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SamoaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Szamoa"),
             new TranslationInfo(LanguageCode.HY, "Սամոա"),
             new TranslationInfo(LanguageCode.ID, "Samoa"),
+            new TranslationInfo(LanguageCode.IS, "Samóa"),
             new TranslationInfo(LanguageCode.IT, "Samoa"),
             new TranslationInfo(LanguageCode.JA, "サモア"),
             new TranslationInfo(LanguageCode.KA, "სამოა"),

--- a/src/Nager.Country.Translation/CountryTranslations/SanMarinoCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SanMarinoCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "San Marino"),
             new TranslationInfo(LanguageCode.HY, "Սան Մարինո"),
             new TranslationInfo(LanguageCode.ID, "San Marino"),
+            new TranslationInfo(LanguageCode.IS, "San Marínó"),
             new TranslationInfo(LanguageCode.IT, "San Marino"),
             new TranslationInfo(LanguageCode.JA, "サンマリノ"),
             new TranslationInfo(LanguageCode.KA, "სან-მარინო"),

--- a/src/Nager.Country.Translation/CountryTranslations/SaoTomeAndPrincipeCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SaoTomeAndPrincipeCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "São Tomé és Príncipe"),
             new TranslationInfo(LanguageCode.HY, "Սան Տոմե և Փրինսիպի"),
             new TranslationInfo(LanguageCode.ID, "Sao Tome dan Principe"),
+            new TranslationInfo(LanguageCode.IS, "Saó Tóme og Prinsipe"),
             new TranslationInfo(LanguageCode.IT, "São Tomé e Príncipe"),
             new TranslationInfo(LanguageCode.JA, "サントメ・プリンシペ"),
             new TranslationInfo(LanguageCode.KA, "სან-ტომე და პრინსიპი"),

--- a/src/Nager.Country.Translation/CountryTranslations/SaudiArabiaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SaudiArabiaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Szaudi-Arábia"),
             new TranslationInfo(LanguageCode.HY, "Սաուդյան Արաբիա"),
             new TranslationInfo(LanguageCode.ID, "Arab Saudi"),
+            new TranslationInfo(LanguageCode.IS, "Sádi-Arabía"),
             new TranslationInfo(LanguageCode.IT, "Arabia Saudita"),
             new TranslationInfo(LanguageCode.JA, "サウジアラビア"),
             new TranslationInfo(LanguageCode.KA, "საუდის არაბეთი"),

--- a/src/Nager.Country.Translation/CountryTranslations/SenegalCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SenegalCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Szenegál"),
             new TranslationInfo(LanguageCode.HY, "Սենեգալ"),
             new TranslationInfo(LanguageCode.ID, "Senegal"),
+            new TranslationInfo(LanguageCode.IS, "Senegal"),
             new TranslationInfo(LanguageCode.IT, "Senegal"),
             new TranslationInfo(LanguageCode.JA, "セネガル"),
             new TranslationInfo(LanguageCode.KA, "სენეგალი"),

--- a/src/Nager.Country.Translation/CountryTranslations/SerbiaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SerbiaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Szerbia"),
             new TranslationInfo(LanguageCode.HY, "Սերբիա"),
             new TranslationInfo(LanguageCode.ID, "Serbia"),
+            new TranslationInfo(LanguageCode.IS, "Serbía"),
             new TranslationInfo(LanguageCode.IT, "Serbia"),
             new TranslationInfo(LanguageCode.JA, "セルビア"),
             new TranslationInfo(LanguageCode.KA, "სერბეთი"),

--- a/src/Nager.Country.Translation/CountryTranslations/SeychellesCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SeychellesCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Seychelle-szigetek"),
             new TranslationInfo(LanguageCode.HY, "Սեյշելներ"),
             new TranslationInfo(LanguageCode.ID, "Seychelles"),
+            new TranslationInfo(LanguageCode.IS, "Seychelles-eyjar"),
             new TranslationInfo(LanguageCode.IT, "Seychelles"),
             new TranslationInfo(LanguageCode.JA, "セーシェル"),
             new TranslationInfo(LanguageCode.KA, "სეიშელის კუნძულები"),

--- a/src/Nager.Country.Translation/CountryTranslations/SierraLeoneCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SierraLeoneCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Sierra Leone"),
             new TranslationInfo(LanguageCode.HY, "Սիեռա Լեոնե"),
             new TranslationInfo(LanguageCode.ID, "Sierra Leone"),
+            new TranslationInfo(LanguageCode.IS, "Síerra Leóne"),
             new TranslationInfo(LanguageCode.IT, "Sierra Leone"),
             new TranslationInfo(LanguageCode.JA, "シエラレオネ"),
             new TranslationInfo(LanguageCode.KA, "სიერა-ლეონე"),

--- a/src/Nager.Country.Translation/CountryTranslations/SingaporeCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SingaporeCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Szingapúr"),
             new TranslationInfo(LanguageCode.HY, "Սինգապուր"),
             new TranslationInfo(LanguageCode.ID, "Singapura"),
+            new TranslationInfo(LanguageCode.IS, "Singapúr"),
             new TranslationInfo(LanguageCode.IT, "Singapore"),
             new TranslationInfo(LanguageCode.JA, "シンガポール"),
             new TranslationInfo(LanguageCode.KA, "სინგაპური"),

--- a/src/Nager.Country.Translation/CountryTranslations/SintMaartenCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SintMaartenCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Szent Márton-sziget (holland rész)"),
             new TranslationInfo(LanguageCode.HY, "Սինտ Մարտեն"),
             new TranslationInfo(LanguageCode.ID, "Sint Maarten (Dutch part)"),
+            new TranslationInfo(LanguageCode.IS, "Sint Maarten"),
             new TranslationInfo(LanguageCode.IT, "Sint Maarten"),
             new TranslationInfo(LanguageCode.JA, "シント・マールテン（オランダ領）"),
             new TranslationInfo(LanguageCode.KA, "სინტ-მარტენი"),

--- a/src/Nager.Country.Translation/CountryTranslations/SlovakiaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SlovakiaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Szlovákia"),
             new TranslationInfo(LanguageCode.HY, "Սլովակիա"),
             new TranslationInfo(LanguageCode.ID, "Slovakia"),
+            new TranslationInfo(LanguageCode.IS, "Slóvakía"),
             new TranslationInfo(LanguageCode.IT, "Slovacchia"),
             new TranslationInfo(LanguageCode.JA, "スロバキア"),
             new TranslationInfo(LanguageCode.KA, "სლოვაკეთი"),

--- a/src/Nager.Country.Translation/CountryTranslations/SloveniaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SloveniaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Szlovénia"),
             new TranslationInfo(LanguageCode.HY, "Սլովենիա"),
             new TranslationInfo(LanguageCode.ID, "Slovenia"),
+            new TranslationInfo(LanguageCode.IS, "Slóvenía"),
             new TranslationInfo(LanguageCode.IT, "Slovenia"),
             new TranslationInfo(LanguageCode.JA, "スロベニア"),
             new TranslationInfo(LanguageCode.KA, "სლოვენია"),

--- a/src/Nager.Country.Translation/CountryTranslations/SolomonIslandsCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SolomonIslandsCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Salamon-szigetek"),
             new TranslationInfo(LanguageCode.HY, "Սողոմոնյան կղզիներ"),
             new TranslationInfo(LanguageCode.ID, "Kepulauan Solomon"),
+            new TranslationInfo(LanguageCode.IS, "Salómonseyjar"),
             new TranslationInfo(LanguageCode.IT, "Isole Salomone"),
             new TranslationInfo(LanguageCode.JA, "ソロモン諸島"),
             new TranslationInfo(LanguageCode.KA, "სოლომონის კუნძულები"),

--- a/src/Nager.Country.Translation/CountryTranslations/SomaliaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SomaliaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Szomália"),
             new TranslationInfo(LanguageCode.HY, "Սոմալի"),
             new TranslationInfo(LanguageCode.ID, "Somalia"),
+            new TranslationInfo(LanguageCode.IS, "Somalía"),
             new TranslationInfo(LanguageCode.IT, "Somalia"),
             new TranslationInfo(LanguageCode.JA, "ソマリア"),
             new TranslationInfo(LanguageCode.KA, "სომალი"),

--- a/src/Nager.Country.Translation/CountryTranslations/SouthAfricaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SouthAfricaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Dél-Afrika"),
             new TranslationInfo(LanguageCode.HY, "Հարավաֆրիկյան Հանրապետություն"),
             new TranslationInfo(LanguageCode.ID, "Afrika Selatan"),
+            new TranslationInfo(LanguageCode.IS, "Suður-Afríka"),
             new TranslationInfo(LanguageCode.IT, "Sudafrica"),
             new TranslationInfo(LanguageCode.JA, "南アフリカ"),
             new TranslationInfo(LanguageCode.KA, "სამხრეთ აფრიკის რესპუბლიკა"),

--- a/src/Nager.Country.Translation/CountryTranslations/SouthGeorgiaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SouthGeorgiaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Déli-Georgia és Déli-Sandwich-szigetek"),
             new TranslationInfo(LanguageCode.HY, "Հարավային Ջորջիա և Հարավային Սենդվիչյան կղզիներ"),
             new TranslationInfo(LanguageCode.ID, "Georgia Selatan dan Kepulauan Sandwich Selatan"),
+            new TranslationInfo(LanguageCode.IS, "Suður-Georgía og Suður-Sandvíkureyjar"),
             new TranslationInfo(LanguageCode.IT, "Georgia del Sud e isole Sandwich meridionali"),
             new TranslationInfo(LanguageCode.JA, "サウスジョージア・サウスサンドウィッチ諸島"),
             new TranslationInfo(LanguageCode.KA, "სამხრეთ ჯორჯია და სამხრეთ სენდვიჩის კუნძულები"),

--- a/src/Nager.Country.Translation/CountryTranslations/SouthKoreaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SouthKoreaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Dél-Korea"),
             new TranslationInfo(LanguageCode.HY, "Հարավային Կորեա"),
             new TranslationInfo(LanguageCode.ID, "Korea Selatan"),
+            new TranslationInfo(LanguageCode.IS, "Suður-Kórea"),
             new TranslationInfo(LanguageCode.IT, "Corea del Sud"),
             new TranslationInfo(LanguageCode.JA, "大韓民国"),
             new TranslationInfo(LanguageCode.KA, "სამხრეთ კორეა"),

--- a/src/Nager.Country.Translation/CountryTranslations/SouthSudanCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SouthSudanCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Dél-Szudán"),
             new TranslationInfo(LanguageCode.HY, "Հարավային Սուդան"),
             new TranslationInfo(LanguageCode.ID, "Sudan Selatan"),
+            new TranslationInfo(LanguageCode.IS, "Suður-Súdan"),
             new TranslationInfo(LanguageCode.IT, "Sudan del Sud"),
             new TranslationInfo(LanguageCode.JA, "南スーダン"),
             new TranslationInfo(LanguageCode.KA, "სამხრეთ სუდანი"),

--- a/src/Nager.Country.Translation/CountryTranslations/SpainCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SpainCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Spanyolország"),
             new TranslationInfo(LanguageCode.HY, "Իսպանիա"),
             new TranslationInfo(LanguageCode.ID, "Spanyol"),
+            new TranslationInfo(LanguageCode.IS, "Spánn"),
             new TranslationInfo(LanguageCode.IT, "Spagna"),
             new TranslationInfo(LanguageCode.JA, "スペイン"),
             new TranslationInfo(LanguageCode.KA, "ესპანეთი"),

--- a/src/Nager.Country.Translation/CountryTranslations/SriLankaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SriLankaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Sri Lanka"),
             new TranslationInfo(LanguageCode.HY, "Շրի Լանկա"),
             new TranslationInfo(LanguageCode.ID, "Sri Lanka"),
+            new TranslationInfo(LanguageCode.IS, "Srí Lanka"),
             new TranslationInfo(LanguageCode.IT, "Sri Lanka"),
             new TranslationInfo(LanguageCode.JA, "スリランカ"),
             new TranslationInfo(LanguageCode.KA, "შრი-ლანკა"),

--- a/src/Nager.Country.Translation/CountryTranslations/SudanCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SudanCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Szudán"),
             new TranslationInfo(LanguageCode.HY, "Սուդան"),
             new TranslationInfo(LanguageCode.ID, "Sudan"),
+            new TranslationInfo(LanguageCode.IS, "Súdan"),
             new TranslationInfo(LanguageCode.IT, "Sudan"),
             new TranslationInfo(LanguageCode.JA, "スーダン"),
             new TranslationInfo(LanguageCode.KA, "სუდანი"),

--- a/src/Nager.Country.Translation/CountryTranslations/SurinameCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SurinameCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Suriname"),
             new TranslationInfo(LanguageCode.HY, "Սուրինամ"),
             new TranslationInfo(LanguageCode.ID, "Suriname"),
+            new TranslationInfo(LanguageCode.IS, "Súrínam"),
             new TranslationInfo(LanguageCode.IT, "Suriname"),
             new TranslationInfo(LanguageCode.JA, "スリナム"),
             new TranslationInfo(LanguageCode.KA, "სურინამი"),

--- a/src/Nager.Country.Translation/CountryTranslations/SvalbardAndJanMayenCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SvalbardAndJanMayenCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Spitzbergák és Jan Mayen"),
             new TranslationInfo(LanguageCode.HY, "Սվալբարդ և Յան Մայեն"),
             new TranslationInfo(LanguageCode.ID, "Svalbard dan Jan Mayen"),
+            new TranslationInfo(LanguageCode.IS, "Svalbarði og Jan Mayen"),
             new TranslationInfo(LanguageCode.IT, "Svalbard e Jan Mayen"),
             new TranslationInfo(LanguageCode.JA, "スヴァールバル諸島およびヤンマイエン島"),
             new TranslationInfo(LanguageCode.KA, "შპიცბერგენი და იან-მაიენი"),

--- a/src/Nager.Country.Translation/CountryTranslations/SwazilandCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SwazilandCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Szváziföld"),
             new TranslationInfo(LanguageCode.HY, "Սվազիլենդ"),
             new TranslationInfo(LanguageCode.ID, "Swaziland"),
+            new TranslationInfo(LanguageCode.IS, "Esvatíní"),
             new TranslationInfo(LanguageCode.IT, "Swaziland"),
             new TranslationInfo(LanguageCode.JA, "スワジランド"),
             new TranslationInfo(LanguageCode.KA, "სვაზილენდი"),

--- a/src/Nager.Country.Translation/CountryTranslations/SwedenCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SwedenCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Svédország"),
             new TranslationInfo(LanguageCode.HY, "Շվեդիա"),
             new TranslationInfo(LanguageCode.ID, "Sweden"),
+            new TranslationInfo(LanguageCode.IS, "Svíþjóð"),
             new TranslationInfo(LanguageCode.IT, "Svezia"),
             new TranslationInfo(LanguageCode.JA, "スウェーデン"),
             new TranslationInfo(LanguageCode.KA, "შვედეთი"),

--- a/src/Nager.Country.Translation/CountryTranslations/SwitzerlandCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SwitzerlandCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Svájc"),
             new TranslationInfo(LanguageCode.HY, "Շվեյցարիա"),
             new TranslationInfo(LanguageCode.ID, "Swiss"),
+            new TranslationInfo(LanguageCode.IS, "Sviss"),
             new TranslationInfo(LanguageCode.IT, "Svizzera"),
             new TranslationInfo(LanguageCode.JA, "スイス"),
             new TranslationInfo(LanguageCode.KA, "შვეიცარია"),

--- a/src/Nager.Country.Translation/CountryTranslations/SyriaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SyriaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Szíria"),
             new TranslationInfo(LanguageCode.HY, "Սիրիա"),
             new TranslationInfo(LanguageCode.ID, "Suriah"),
+            new TranslationInfo(LanguageCode.IS, "Sýrland"),
             new TranslationInfo(LanguageCode.IT, "Siria"),
             new TranslationInfo(LanguageCode.JA, "シリア・アラブ共和国"),
             new TranslationInfo(LanguageCode.KA, "სირია"),

--- a/src/Nager.Country.Translation/CountryTranslations/TaiwanCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/TaiwanCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Tajvan"),
             new TranslationInfo(LanguageCode.HY, "Թայվան"),
             new TranslationInfo(LanguageCode.ID, "Taiwan"),
+            new TranslationInfo(LanguageCode.IS, "Taívan"),
             new TranslationInfo(LanguageCode.IT, "Repubblica di Cina"),
             new TranslationInfo(LanguageCode.JA, "台湾"),
             new TranslationInfo(LanguageCode.KA, "ტაივანი"),

--- a/src/Nager.Country.Translation/CountryTranslations/TajikistanCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/TajikistanCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Tádzsikisztán"),
             new TranslationInfo(LanguageCode.HY, "Տաջիկստան"),
             new TranslationInfo(LanguageCode.ID, "Tajikistan"),
+            new TranslationInfo(LanguageCode.IS, "Tadsíkistan"),
             new TranslationInfo(LanguageCode.IT, "Tagikistan"),
             new TranslationInfo(LanguageCode.JA, "タジキスタン"),
             new TranslationInfo(LanguageCode.KA, "ტაჯიკეთი"),

--- a/src/Nager.Country.Translation/CountryTranslations/TanzaniaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/TanzaniaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Tanzánia"),
             new TranslationInfo(LanguageCode.HY, "Տանզանիա"),
             new TranslationInfo(LanguageCode.ID, "Tanzania"),
+            new TranslationInfo(LanguageCode.IS, "Tansanía"),
             new TranslationInfo(LanguageCode.IT, "Tanzania"),
             new TranslationInfo(LanguageCode.JA, "タンザニア"),
             new TranslationInfo(LanguageCode.KA, "ტანზანია"),

--- a/src/Nager.Country.Translation/CountryTranslations/ThailandCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/ThailandCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Thaiföld"),
             new TranslationInfo(LanguageCode.HY, "Թայլանդ"),
             new TranslationInfo(LanguageCode.ID, "Thailand"),
+            new TranslationInfo(LanguageCode.IS, "Taíland"),
             new TranslationInfo(LanguageCode.IT, "Thailandia"),
             new TranslationInfo(LanguageCode.JA, "タイ"),
             new TranslationInfo(LanguageCode.KA, "ტაილანდი"),

--- a/src/Nager.Country.Translation/CountryTranslations/TimorLesteCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/TimorLesteCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Kelet-Timor"),
             new TranslationInfo(LanguageCode.HY, "Թիմոր Լեշտի"),
             new TranslationInfo(LanguageCode.ID, "Timor-Leste"),
+            new TranslationInfo(LanguageCode.IS, "Tímor-Leste"),
             new TranslationInfo(LanguageCode.IT, "Timor Est"),
             new TranslationInfo(LanguageCode.JA, "東ティモール"),
             new TranslationInfo(LanguageCode.KA, "ტიმორ-ლესტე"),

--- a/src/Nager.Country.Translation/CountryTranslations/TogoCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/TogoCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Togo"),
             new TranslationInfo(LanguageCode.HY, "Տոգո"),
             new TranslationInfo(LanguageCode.ID, "Togo"),
+            new TranslationInfo(LanguageCode.IS, "Tógó"),
             new TranslationInfo(LanguageCode.IT, "Togo"),
             new TranslationInfo(LanguageCode.JA, "トーゴ"),
             new TranslationInfo(LanguageCode.KA, "ტოგო"),

--- a/src/Nager.Country.Translation/CountryTranslations/TokelauCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/TokelauCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Tokelau-szigetek"),
             new TranslationInfo(LanguageCode.HY, "Տոկելաու"),
             new TranslationInfo(LanguageCode.ID, "Tokelau"),
+            new TranslationInfo(LanguageCode.IS, "Tókelá"),
             new TranslationInfo(LanguageCode.IT, "Tokelau"),
             new TranslationInfo(LanguageCode.JA, "トケラウ"),
             new TranslationInfo(LanguageCode.KA, "ტოკელაუ"),

--- a/src/Nager.Country.Translation/CountryTranslations/TongaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/TongaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Tonga"),
             new TranslationInfo(LanguageCode.HY, "Տոնգա"),
             new TranslationInfo(LanguageCode.ID, "Tonga"),
+            new TranslationInfo(LanguageCode.IS, "Tonga"),
             new TranslationInfo(LanguageCode.IT, "Tonga"),
             new TranslationInfo(LanguageCode.JA, "トンガ"),
             new TranslationInfo(LanguageCode.KA, "ტონგა"),

--- a/src/Nager.Country.Translation/CountryTranslations/TrinidadAndTobagoCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/TrinidadAndTobagoCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Trinidad és Tobago"),
             new TranslationInfo(LanguageCode.HY, "Տրինիդադ և Տոբագո"),
             new TranslationInfo(LanguageCode.ID, "Trinidad dan Tobago"),
+            new TranslationInfo(LanguageCode.IS, "Trínidad og Tóbagó"),
             new TranslationInfo(LanguageCode.IT, "Trinidad e Tobago"),
             new TranslationInfo(LanguageCode.JA, "トリニダード・トバゴ"),
             new TranslationInfo(LanguageCode.KA, "ტრინიდადი და ტობაგო"),

--- a/src/Nager.Country.Translation/CountryTranslations/TunisiaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/TunisiaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Tunézia"),
             new TranslationInfo(LanguageCode.HY, "Թունիս"),
             new TranslationInfo(LanguageCode.ID, "Tunisia"),
+            new TranslationInfo(LanguageCode.IS, "Túnis"),
             new TranslationInfo(LanguageCode.IT, "Tunisia"),
             new TranslationInfo(LanguageCode.JA, "チュニジア"),
             new TranslationInfo(LanguageCode.KA, "ტუნისი"),

--- a/src/Nager.Country.Translation/CountryTranslations/TurkeyCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/TurkeyCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Törökország"),
             new TranslationInfo(LanguageCode.HY, "Թուրքիա"),
             new TranslationInfo(LanguageCode.ID, "Turki"),
+            new TranslationInfo(LanguageCode.IS, "Tyrkland"),
             new TranslationInfo(LanguageCode.IT, "Turchia"),
             new TranslationInfo(LanguageCode.JA, "トルコ"),
             new TranslationInfo(LanguageCode.KA, "თურქეთი"),

--- a/src/Nager.Country.Translation/CountryTranslations/TurkmenistanCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/TurkmenistanCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Türkmenisztán"),
             new TranslationInfo(LanguageCode.HY, "Թուրքմենստան"),
             new TranslationInfo(LanguageCode.ID, "Turkmenistan"),
+            new TranslationInfo(LanguageCode.IS, "Túrkmenistan"),
             new TranslationInfo(LanguageCode.IT, "Turkmenistan"),
             new TranslationInfo(LanguageCode.JA, "トルクメニスタン"),
             new TranslationInfo(LanguageCode.KA, "თურქმენეთი"),

--- a/src/Nager.Country.Translation/CountryTranslations/TurksAndCaicosIslandsCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/TurksAndCaicosIslandsCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Turks- és Caicos-szigetek"),
             new TranslationInfo(LanguageCode.HY, "Թըրքս և Կայկոս կղզիներ"),
             new TranslationInfo(LanguageCode.ID, "Turks dan Caicos Islands"),
+            new TranslationInfo(LanguageCode.IS, "Turks- og Caicos-eyjar"),
             new TranslationInfo(LanguageCode.IT, "Isole Turks e Caicos"),
             new TranslationInfo(LanguageCode.JA, "タークス・カイコス諸島"),
             new TranslationInfo(LanguageCode.KA, "თერქს-ქაიქოსის კუნძულები"),

--- a/src/Nager.Country.Translation/CountryTranslations/TuvaluCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/TuvaluCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Tuvalu"),
             new TranslationInfo(LanguageCode.HY, "Տուվալու"),
             new TranslationInfo(LanguageCode.ID, "Tuvalu"),
+            new TranslationInfo(LanguageCode.IS, "Túvalú"),
             new TranslationInfo(LanguageCode.IT, "Tuvalu"),
             new TranslationInfo(LanguageCode.JA, "ツバル"),
             new TranslationInfo(LanguageCode.KA, "ტუვალუ"),

--- a/src/Nager.Country.Translation/CountryTranslations/UgandaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/UgandaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Uganda"),
             new TranslationInfo(LanguageCode.HY, "Ուգանդա"),
             new TranslationInfo(LanguageCode.ID, "Uganda"),
+            new TranslationInfo(LanguageCode.IS, "Úganda"),
             new TranslationInfo(LanguageCode.IT, "Uganda"),
             new TranslationInfo(LanguageCode.JA, "ウガンダ"),
             new TranslationInfo(LanguageCode.KA, "უგანდა"),

--- a/src/Nager.Country.Translation/CountryTranslations/UkraineCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/UkraineCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Ukrajna"),
             new TranslationInfo(LanguageCode.HY, "Ուկրաինա"),
             new TranslationInfo(LanguageCode.ID, "Ukraina"),
+            new TranslationInfo(LanguageCode.IS, "Úkraína"),
             new TranslationInfo(LanguageCode.IT, "Ucraina"),
             new TranslationInfo(LanguageCode.JA, "ウクライナ"),
             new TranslationInfo(LanguageCode.KA, "უკრაინა"),

--- a/src/Nager.Country.Translation/CountryTranslations/UnitedArabEmiratesCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/UnitedArabEmiratesCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Egyesült Arab Emírségek"),
             new TranslationInfo(LanguageCode.HY, "Արաբական Միացյալ Էմիրություններ"),
             new TranslationInfo(LanguageCode.ID, "Uni Emirat Arab"),
+            new TranslationInfo(LanguageCode.IS, "Sameinuðu arabísku furstadæmin"),
             new TranslationInfo(LanguageCode.IT, "Emirati Arabi Uniti"),
             new TranslationInfo(LanguageCode.JA, "アラブ首長国連邦"),
             new TranslationInfo(LanguageCode.KA, "არაბთა გაერთიანებული საამიროები"),

--- a/src/Nager.Country.Translation/CountryTranslations/UnitedKingdomCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/UnitedKingdomCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Egyesült Királyság"),
             new TranslationInfo(LanguageCode.HY, "Միացյալ Թագավորություն"),
             new TranslationInfo(LanguageCode.ID, "Britania Raya"),
+            new TranslationInfo(LanguageCode.IS, "Bretland"),
             new TranslationInfo(LanguageCode.IT, "Regno Unito"),
             new TranslationInfo(LanguageCode.JA, "イギリス"),
             new TranslationInfo(LanguageCode.KA, "გაერთიანებული სამეფო"),

--- a/src/Nager.Country.Translation/CountryTranslations/UnitedStatesCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/UnitedStatesCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Amerikai Egyesült Államok"),
             new TranslationInfo(LanguageCode.HY, "Միացյալ Նահանգներ"),
             new TranslationInfo(LanguageCode.ID, "Amerika Serikat"),
+            new TranslationInfo(LanguageCode.IS, "Bandaríkin"),
             new TranslationInfo(LanguageCode.IT, "Stati Uniti d'America"),
             new TranslationInfo(LanguageCode.JA, "アメリカ合衆国"),
             new TranslationInfo(LanguageCode.KA, "ამერიკის შეერთებული შტატები"),

--- a/src/Nager.Country.Translation/CountryTranslations/UnitedStatesVirginIslandsCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/UnitedStatesVirginIslandsCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Amerikai Virgin-szigetek"),
             new TranslationInfo(LanguageCode.HY, "ԱՄՆ Վիրջինյան կղզիներ"),
             new TranslationInfo(LanguageCode.ID, "Virgin Islands, U.S."),
+            new TranslationInfo(LanguageCode.IS, "Bandarísku Jómfrúaeyjar"),
             new TranslationInfo(LanguageCode.IT, "Isole Vergini Americane"),
             new TranslationInfo(LanguageCode.JA, "アメリカ領ヴァージン諸島"),
             new TranslationInfo(LanguageCode.KA, "აშშ-ის ვირჯინის კუნძულები"),

--- a/src/Nager.Country.Translation/CountryTranslations/UruguayCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/UruguayCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Uruguay"),
             new TranslationInfo(LanguageCode.HY, "Ուրուգվայ"),
             new TranslationInfo(LanguageCode.ID, "Uruguay"),
+            new TranslationInfo(LanguageCode.IS, "Úrúgvæ"),
             new TranslationInfo(LanguageCode.IT, "Uruguay"),
             new TranslationInfo(LanguageCode.JA, "ウルグアイ"),
             new TranslationInfo(LanguageCode.KA, "ურუგვაი"),

--- a/src/Nager.Country.Translation/CountryTranslations/UzbekistanCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/UzbekistanCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Üzbegisztán"),
             new TranslationInfo(LanguageCode.HY, "Ուզբեկստան"),
             new TranslationInfo(LanguageCode.ID, "Uzbekistan"),
+            new TranslationInfo(LanguageCode.IS, "Úsbekistan"),
             new TranslationInfo(LanguageCode.IT, "Uzbekistan"),
             new TranslationInfo(LanguageCode.JA, "ウズベキスタン"),
             new TranslationInfo(LanguageCode.KA, "უზბეკეთი"),

--- a/src/Nager.Country.Translation/CountryTranslations/VanuatuCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/VanuatuCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Vanuatu"),
             new TranslationInfo(LanguageCode.HY, "Վանուատու"),
             new TranslationInfo(LanguageCode.ID, "Vanuatu"),
+            new TranslationInfo(LanguageCode.IS, "Vanúatú"),
             new TranslationInfo(LanguageCode.IT, "Vanuatu"),
             new TranslationInfo(LanguageCode.JA, "バヌアツ"),
             new TranslationInfo(LanguageCode.KA, "ვანუატუ"),

--- a/src/Nager.Country.Translation/CountryTranslations/VaticanCityCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/VaticanCityCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Vatikán"),
             new TranslationInfo(LanguageCode.HY, "Վատիկան"),
             new TranslationInfo(LanguageCode.ID, "Vatikan"),
+            new TranslationInfo(LanguageCode.IS, "Vatíkanið"),
             new TranslationInfo(LanguageCode.IT, "Città del Vaticano"),
             new TranslationInfo(LanguageCode.JA, "バチカン市国"),
             new TranslationInfo(LanguageCode.KA, "ქალაქი ვატიკანი"),

--- a/src/Nager.Country.Translation/CountryTranslations/VenezuelaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/VenezuelaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Venezuela"),
             new TranslationInfo(LanguageCode.HY, "Վենեսուելա"),
             new TranslationInfo(LanguageCode.ID, "Venezuela"),
+            new TranslationInfo(LanguageCode.IS, "Venesúela"),
             new TranslationInfo(LanguageCode.IT, "Venezuela"),
             new TranslationInfo(LanguageCode.JA, "ベネズエラ・ボリバル共和国"),
             new TranslationInfo(LanguageCode.KA, "ვენესუელა"),

--- a/src/Nager.Country.Translation/CountryTranslations/VietnamCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/VietnamCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Vietnam"),
             new TranslationInfo(LanguageCode.HY, "Վիետնամ"),
             new TranslationInfo(LanguageCode.ID, "Viet Nam"),
+            new TranslationInfo(LanguageCode.IS, "Víetnam"),
             new TranslationInfo(LanguageCode.IT, "Vietnam"),
             new TranslationInfo(LanguageCode.JA, "ベトナム"),
             new TranslationInfo(LanguageCode.KA, "ვიეტნამი"),

--- a/src/Nager.Country.Translation/CountryTranslations/WallisAndFutunaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/WallisAndFutunaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Wallis és Futuna"),
             new TranslationInfo(LanguageCode.HY, "Ուոլիս և Ֆուտունա"),
             new TranslationInfo(LanguageCode.ID, "Wallis and Futuna"),
+            new TranslationInfo(LanguageCode.IS, "Wallis- og Fútúnaeyjar"),
             new TranslationInfo(LanguageCode.IT, "Wallis e Futuna"),
             new TranslationInfo(LanguageCode.JA, "ウォリス・フツナ"),
             new TranslationInfo(LanguageCode.KA, "უოლისი და ფუტუნა"),

--- a/src/Nager.Country.Translation/CountryTranslations/WesternSaharaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/WesternSaharaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Nyugat-Szahara"),
             new TranslationInfo(LanguageCode.HY, "Արևմտյան Սահարա"),
             new TranslationInfo(LanguageCode.ID, "Sahara Barat"),
+            new TranslationInfo(LanguageCode.IS, "Vestur-Sahara"),
             new TranslationInfo(LanguageCode.IT, "Sahara Occidentale"),
             new TranslationInfo(LanguageCode.JA, "西サハラ"),
             new TranslationInfo(LanguageCode.KA, "დასავლეთ საჰარა"),

--- a/src/Nager.Country.Translation/CountryTranslations/YemenCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/YemenCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Jemen"),
             new TranslationInfo(LanguageCode.HY, "Եմեն"),
             new TranslationInfo(LanguageCode.ID, "Yaman"),
+            new TranslationInfo(LanguageCode.IS, "Jemen"),
             new TranslationInfo(LanguageCode.IT, "Yemen"),
             new TranslationInfo(LanguageCode.JA, "イエメン"),
             new TranslationInfo(LanguageCode.KA, "იემენი"),

--- a/src/Nager.Country.Translation/CountryTranslations/ZambiaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/ZambiaCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Zambia"),
             new TranslationInfo(LanguageCode.HY, "Զամբիա"),
             new TranslationInfo(LanguageCode.ID, "Zambia"),
+            new TranslationInfo(LanguageCode.IS, "Sambía"),
             new TranslationInfo(LanguageCode.IT, "Zambia"),
             new TranslationInfo(LanguageCode.JA, "ザンビア"),
             new TranslationInfo(LanguageCode.KA, "ზამბია"),

--- a/src/Nager.Country.Translation/CountryTranslations/ZimbabweCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/ZimbabweCountryTranslation.cs
@@ -29,6 +29,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.HU, "Zimbabwe"),
             new TranslationInfo(LanguageCode.HY, "Զիմբաբվե"),
             new TranslationInfo(LanguageCode.ID, "Zimbabwe"),
+            new TranslationInfo(LanguageCode.IS, "Simbabve"),
             new TranslationInfo(LanguageCode.IT, "Zimbabwe"),
             new TranslationInfo(LanguageCode.JA, "ジンバブエ"),
             new TranslationInfo(LanguageCode.KA, "ზიმბაბვე"),


### PR DESCRIPTION
Added Icelandic country name translations.

Translations were sourced from [Árnastofnun](https://www.arnastofnun.is/is/rikjaheiti) and [Icelandic Wikipedia](https://is.wikipedia.org/)