### PR TITLE
Update DutchLanguageTranslation.cs

### DIFF
--- a/src/Nager.Country.Translation/LanguageTranslations/DutchLanguageTranslation.cs
+++ b/src/Nager.Country.Translation/LanguageTranslations/DutchLanguageTranslation.cs
@@ -10,7 +10,7 @@ namespace Nager.Country.Translation.LanguageTranslations
         ///<inheritdoc/>
         public TranslationInfo[] Translations => new[]
         {
-            new TranslationInfo(LanguageCode.AF, "Duits"),
+            new TranslationInfo(LanguageCode.AF, "Nederlands"),
             new TranslationInfo(LanguageCode.AM, "ደች"),
             new TranslationInfo(LanguageCode.AR, "الهولندي"),
             new TranslationInfo(LanguageCode.AZ, "Hollandiya"),


### PR DESCRIPTION
Translation of Dutch Language in Afrikaans was incorrect (Wat translated to Duits, which is German, and not Dutch)