### PR TITLE
Change Swedish names for Belarus

### DIFF
--- a/src/Nager.Country.Translation/CountryTranslations/BelarusCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/BelarusCountryTranslation.cs
@@ -50,7 +50,7 @@ namespace Nager.Country.Translation.CountryInfos
             new TranslationInfo(LanguageCode.SK, "Bielorusko"),
             new TranslationInfo(LanguageCode.SL, "Belorusija"),
             new TranslationInfo(LanguageCode.SR, "Белорусија"),
-            new TranslationInfo(LanguageCode.SV, "Vitryssland"),
+            new TranslationInfo(LanguageCode.SV, "Belarus"),
             new TranslationInfo(LanguageCode.TR, "Beyaz Rusya"),
             new TranslationInfo(LanguageCode.UK, "Білорусь"),
             new TranslationInfo(LanguageCode.UZ, "Belarus"),

--- a/src/Nager.Country.Translation/LanguageTranslations/BelarusianLanguageTranslation.cs
+++ b/src/Nager.Country.Translation/LanguageTranslations/BelarusianLanguageTranslation.cs
@@ -81,7 +81,7 @@ namespace Nager.Country.Translation.LanguageTranslations
             new TranslationInfo(LanguageCode.SQ, "Bjellorusisht"),
             new TranslationInfo(LanguageCode.SR, "Белоруски"),
             new TranslationInfo(LanguageCode.SU, "Belarusian"),
-            new TranslationInfo(LanguageCode.SV, "Vitryska"),
+            new TranslationInfo(LanguageCode.SV, "Belarusiska"),
             new TranslationInfo(LanguageCode.SW, "Kibelarusi"),
             new TranslationInfo(LanguageCode.TA, "பைலோருஷ்ன்"),
             new TranslationInfo(LanguageCode.TE, "బెలరుశియన్"),


### PR DESCRIPTION
adopt to new names in Sweden for Belarus. Source: https://www.riksdagen.se/sv/dokument-och-lagar/dokument/skriftlig-fraga/byte-av-namnet-vitryssland-till-belarus_gw111120/