### PR TITLE
Assign numeric values to Alpha2Code enum members

### DIFF
--- a/src/Nager.Country/Alpha2Code.cs
+++ b/src/Nager.Country/Alpha2Code.cs
@@ -3,1004 +3,1008 @@
     /// <summary>
     /// Alpha2 code (ISO-3166-1)
     /// </summary>
-    public enum Alpha2Code
+    /// <remarks>
+    /// The numeric value is built by concatenating the ASCII codes of the two characters. 
+    /// Example: "AF" → 'A' (65) + 'F' (70) = 6570
+    /// </remarks>
+    public enum Alpha2Code : int
     {
         /// <summary>
         /// Afghanistan
         /// </summary>
-        AF,
+        AF = 6570,
         /// <summary>
         /// Åland
         /// </summary>
-        AX,
+        AX = 6588,
         /// <summary>
         /// Albania
         /// </summary>
-        AL,
+        AL = 6576,
         /// <summary>
         /// Algeria
         /// </summary>
-        DZ,
+        DZ = 6890,
         /// <summary>
         /// American Samoa
         /// </summary>
-        AS,
+        AS = 6583,
         /// <summary>
         /// Andorra
         /// </summary>
-        AD,
+        AD = 6568,
         /// <summary>
         /// Angola
         /// </summary>
-        AO,
+        AO = 6579,
         /// <summary>
         /// Anguilla
         /// </summary>
-        AI,
+        AI = 6573,
         /// <summary>
         /// Antarctica
         /// </summary>
-        AQ,
+        AQ = 6581,
         /// <summary>
         /// Antigua and Barbuda
         /// </summary>
-        AG,
+        AG = 6571,
         /// <summary>
         /// Argentina
         /// </summary>
-        AR,
+        AR = 6582,
         /// <summary>
         /// Armenia
         /// </summary>
-        AM,
+        AM = 6577,
         /// <summary>
         /// Aruba
         /// </summary>
-        AW,
+        AW = 6587,
         /// <summary>
         /// Australia
         /// </summary>
-        AU,
+        AU = 6585,
         /// <summary>
         /// Austria
         /// </summary>
-        AT,
+        AT = 6584,
         /// <summary>
         /// Azerbaijan
         /// </summary>
-        AZ,
+        AZ = 6590,
         /// <summary>
         /// Bahamas
         /// </summary>
-        BS,
+        BS = 6683,
         /// <summary>
         /// Bahrain
         /// </summary>
-        BH,
+        BH = 6672,
         /// <summary>
         /// Bangladesh
         /// </summary>
-        BD,
+        BD = 6668,
         /// <summary>
         /// Barbados
         /// </summary>
-        BB,
+        BB = 6666,
         /// <summary>
         /// Belarus
         /// </summary>
-        BY,
+        BY = 6689,
         /// <summary>
         /// Belgium
         /// </summary>
-        BE,
+        BE = 6669,
         /// <summary>
         /// Belize
         /// </summary>
-        BZ,
+        BZ = 6690,
         /// <summary>
         /// Benin
         /// </summary>
-        BJ,
+        BJ = 6674,
         /// <summary>
         /// Bermuda
         /// </summary>
-        BM,
+        BM = 6677,
         /// <summary>
         /// Bhutan
         /// </summary>
-        BT,
+        BT = 6684,
         /// <summary>
         /// Bolivia
         /// </summary>
-        BO,
+        BO = 6679,
         /// <summary>
         /// Bonaire, Sint Eustatius and Saba
         /// </summary>
-        BQ,
+        BQ = 6681,
         /// <summary>
         /// Bosnia and Herzegovina
         /// </summary>
-        BA,
+        BA = 6665,
         /// <summary>
         /// Botswana
         /// </summary>
-        BW,
+        BW = 6687,
         /// <summary>
         /// Bouvet Island
         /// </summary>
-        BV,
+        BV = 6686,
         /// <summary>
         /// Brazil
         /// </summary>
-        BR,
+        BR = 6682,
         /// <summary>
         /// British Indian Ocean Territory
         /// </summary>
-        IO,
+        IO = 7379,
         /// <summary>
         /// Brunei Darussalam
         /// </summary>
-        BN,
+        BN = 6678,
         /// <summary>
         /// Bulgaria
         /// </summary>
-        BG,
+        BG = 6671,
         /// <summary>
         /// Burkina Faso
         /// </summary>
-        BF,
+        BF = 6670,
         /// <summary>
         /// Burundi
         /// </summary>
-        BI,
+        BI = 6673,
         /// <summary>
         /// Cambodia
         /// </summary>
-        KH,
+        KH = 7572,
         /// <summary>
         /// Cameroon
         /// </summary>
-        CM,
+        CM = 6777,
         /// <summary>
         /// Canada
         /// </summary>
-        CA,
+        CA = 6765,
         /// <summary>
         /// Cape Verde
         /// </summary>
-        CV,
+        CV = 6786,
         /// <summary>
         /// Cayman Islands
         /// </summary>
-        KY,
+        KY = 7589,
         /// <summary>
         /// Central African Republic
         /// </summary>
-        CF,
+        CF = 6770,
         /// <summary>
         /// Chad
         /// </summary>
-        TD,
+        TD = 8468,
         /// <summary>
         /// Chile
         /// </summary>
-        CL,
+        CL = 6776,
         /// <summary>
         /// China
         /// </summary>
-        CN,
+        CN = 6778,
         /// <summary>
         /// Christmas Island
         /// </summary>
-        CX,
+        CX = 6788,
         /// <summary>
         /// Cocos (Keeling) Islands
         /// </summary>
-        CC,
+        CC = 6767,
         /// <summary>
         /// Colombia
         /// </summary>
-        CO,
+        CO = 6779,
         /// <summary>
         /// Comoros
         /// </summary>
-        KM,
+        KM = 7577,
         /// <summary>
         /// Congo (Brazzaville)
         /// </summary>
-        CG,
+        CG = 6771,
         /// <summary>
         /// Congo (Kinshasa)
         /// </summary>
-        CD,
+        CD = 6768,
         /// <summary>
         /// Cook Islands
         /// </summary>
-        CK,
+        CK = 6775,
         /// <summary>
         /// Costa Rica
         /// </summary>
-        CR,
+        CR = 6782,
         /// <summary>
         /// Côte d'Ivoire
         /// </summary>
-        CI,
+        CI = 6773,
         /// <summary>
         /// Croatia
         /// </summary>
-        HR,
+        HR = 7282,
         /// <summary>
         /// Cuba
         /// </summary>
-        CU,
+        CU = 6785,
         /// <summary>
         /// Curaçao
         /// </summary>
-        CW,
+        CW = 6787,
         /// <summary>
         /// Cyprus
         /// </summary>
-        CY,
+        CY = 6789,
         /// <summary>
         /// Czech Republic
         /// </summary>
-        CZ,
+        CZ = 6790,
         /// <summary>
         /// Denmark
         /// </summary>
-        DK,
+        DK = 6875,
         /// <summary>
         /// Djibouti
         /// </summary>
-        DJ,
+        DJ = 6874,
         /// <summary>
         /// Dominica
         /// </summary>
-        DM,
+        DM = 6877,
         /// <summary>
         /// Dominican Republic
         /// </summary>
-        DO,
+        DO = 6879,
         /// <summary>
         /// Ecuador
         /// </summary>
-        EC,
+        EC = 6967,
         /// <summary>
         /// Egypt
         /// </summary>
-        EG,
+        EG = 6971,
         /// <summary>
         /// El Salvador
         /// </summary>
-        SV,
+        SV = 8386,
         /// <summary>
         /// Equatorial Guinea
         /// </summary>
-        GQ,
+        GQ = 7181,
         /// <summary>
         /// Eritrea
         /// </summary>
-        ER,
+        ER = 6982,
         /// <summary>
         /// Estonia
         /// </summary>
-        EE,
+        EE = 6969,
         /// <summary>
         /// Ethiopia
         /// </summary>
-        ET,
+        ET = 6984,
         /// <summary>
         /// Falkland Islands
         /// </summary>
-        FK,
+        FK = 7075,
         /// <summary>
         /// Faroe Islands
         /// </summary>
-        FO,
+        FO = 7079,
         /// <summary>
         /// Fiji
         /// </summary>
-        FJ,
+        FJ = 7074,
         /// <summary>
         /// Finland
         /// </summary>
-        FI,
+        FI = 7073,
         /// <summary>
         /// France
         /// </summary>
-        FR,
+        FR = 7082,
         /// <summary>
         /// French Guiana
         /// </summary>
-        GF,
+        GF = 7170,
         /// <summary>
         /// French Polynesia
         /// </summary>
-        PF,
+        PF = 8070,
         /// <summary>
         /// French Southern Lands
         /// </summary>
-        TF,
+        TF = 8470,
         /// <summary>
         /// Gabon
         /// </summary>
-        GA,
+        GA = 7165,
         /// <summary>
         /// Gambia
         /// </summary>
-        GM,
+        GM = 7177,
         /// <summary>
         /// Georgia
         /// </summary>
-        GE,
+        GE = 7169,
         /// <summary>
         /// Germany
         /// </summary>
-        DE,
+        DE = 6869,
         /// <summary>
         /// Ghana
         /// </summary>
-        GH,
+        GH = 7172,
         /// <summary>
         /// Gibraltar
         /// </summary>
-        GI,
+        GI = 7173,
         /// <summary>
         /// Greece
         /// </summary>
-        GR,
+        GR = 7182,
         /// <summary>
         /// Greenland
         /// </summary>
-        GL,
+        GL = 7176,
         /// <summary>
         /// Grenada
         /// </summary>
-        GD,
+        GD = 7168,
         /// <summary>
         /// Guadeloupe
         /// </summary>
-        GP,
+        GP = 7180,
         /// <summary>
         /// Guam
         /// </summary>
-        GU,
+        GU = 7185,
         /// <summary>
         /// Guatemala
         /// </summary>
-        GT,
+        GT = 7184,
         /// <summary>
         /// Guernsey
         /// </summary>
-        GG,
+        GG = 7171,
         /// <summary>
         /// Guinea
         /// </summary>
-        GN,
+        GN = 7178,
         /// <summary>
         /// Guinea-Bissau
         /// </summary>
-        GW,
+        GW = 7187,
         /// <summary>
         /// Guyana
         /// </summary>
-        GY,
+        GY = 7189,
         /// <summary>
         /// Haiti
         /// </summary>
-        HT,
+        HT = 7284,
         /// <summary>
         /// Heard and McDonald Islands
         /// </summary>
-        HM,
+        HM = 7277,
         /// <summary>
         /// Honduras
         /// </summary>
-        HN,
+        HN = 7278,
         /// <summary>
         /// Hong Kong
         /// </summary>
-        HK,
+        HK = 7275,
         /// <summary>
         /// Hungary
         /// </summary>
-        HU,
+        HU = 7285,
         /// <summary>
         /// Iceland
         /// </summary>
-        IS,
+        IS = 7383,
         /// <summary>
         /// India
         /// </summary>
-        IN,
+        IN = 7378,
         /// <summary>
         /// Indonesia
         /// </summary>
-        ID,
+        ID = 7368,
         /// <summary>
         /// Iran
         /// </summary>
-        IR,
+        IR = 7382,
         /// <summary>
         /// Iraq
         /// </summary>
-        IQ,
+        IQ = 7381,
         /// <summary>
         /// Ireland
         /// </summary>
-        IE,
+        IE = 7369,
         /// <summary>
         /// Isle of Man
         /// </summary>
-        IM,
+        IM = 7377,
         /// <summary>
         /// Israel
         /// </summary>
-        IL,
+        IL = 7376,
         /// <summary>
         /// Italy
         /// </summary>
-        IT,
+        IT = 7384,
         /// <summary>
         /// Jamaica
         /// </summary>
-        JM,
+        JM = 7477,
         /// <summary>
         /// Japan
         /// </summary>
-        JP,
+        JP = 7480,
         /// <summary>
         /// Jersey
         /// </summary>
-        JE,
+        JE = 7469,
         /// <summary>
         /// Jordan
         /// </summary>
-        JO,
+        JO = 7479,
         /// <summary>
         /// Kazakhstan
         /// </summary>
-        KZ,
+        KZ = 7590,
         /// <summary>
         /// Kenya
         /// </summary>
-        KE,
+        KE = 7569,
         /// <summary>
         /// Kiribati
         /// </summary>
-        KI,
+        KI = 7573,
         /// <summary>
         /// Korea, North
         /// </summary>
-        KP,
+        KP = 7580,
         /// <summary>
         /// Korea, South
         /// </summary>
-        KR,
+        KR = 7582,
         /// <summary>
         /// Kosovo (partially recognized; not a UN member state)
         /// </summary>
-        XK,
+        XK = 8875,
         /// <summary>
         /// Kuwait
         /// </summary>
-        KW,
+        KW = 7587,
         /// <summary>
         /// Kyrgyzstan
         /// </summary>
-        KG,
+        KG = 7571,
         /// <summary>
         /// Laos
         /// </summary>
-        LA,
+        LA = 7665,
         /// <summary>
         /// Latvia
         /// </summary>
-        LV,
+        LV = 7686,
         /// <summary>
         /// Lebanon
         /// </summary>
-        LB,
+        LB = 7666,
         /// <summary>
         /// Lesotho
         /// </summary>
-        LS,
+        LS = 7683,
         /// <summary>
         /// Liberia
         /// </summary>
-        LR,
+        LR = 7682,
         /// <summary>
         /// Libya
         /// </summary>
-        LY,
+        LY = 7689,
         /// <summary>
         /// Liechtenstein
         /// </summary>
-        LI,
+        LI = 7673,
         /// <summary>
         /// Lithuania
         /// </summary>
-        LT,
+        LT = 7684,
         /// <summary>
         /// Luxembourg
         /// </summary>
-        LU,
+        LU = 7685,
         /// <summary>
         /// Macau
         /// </summary>
-        MO,
+        MO = 7779,
         /// <summary>
         /// North Macedonia
         /// </summary>
-        MK,
+        MK = 7775,
         /// <summary>
         /// Madagascar
         /// </summary>
-        MG,
+        MG = 7771,
         /// <summary>
         /// Malawi
         /// </summary>
-        MW,
+        MW = 7787,
         /// <summary>
         /// Malaysia
         /// </summary>
-        MY,
+        MY = 7789,
         /// <summary>
         /// Maldives
         /// </summary>
-        MV,
+        MV = 7786,
         /// <summary>
         /// Mali
         /// </summary>
-        ML,
+        ML = 7776,
         /// <summary>
         /// Malta
         /// </summary>
-        MT,
+        MT = 7784,
         /// <summary>
         /// Marshall Islands
         /// </summary>
-        MH,
+        MH = 7772,
         /// <summary>
         /// Martinique
         /// </summary>
-        MQ,
+        MQ = 7781,
         /// <summary>
         /// Mauritania
         /// </summary>
-        MR,
+        MR = 7782,
         /// <summary>
         /// Mauritius
         /// </summary>
-        MU,
+        MU = 7785,
         /// <summary>
         /// Mayotte
         /// </summary>
-        YT,
+        YT = 8984,
         /// <summary>
         /// Mexico
         /// </summary>
-        MX,
+        MX = 7788,
         /// <summary>
         /// Micronesia
         /// </summary>
-        FM,
+        FM = 7077,
         /// <summary>
         /// Moldova
         /// </summary>
-        MD,
+        MD = 7768,
         /// <summary>
         /// Monaco
         /// </summary>
-        MC,
+        MC = 7767,
         /// <summary>
         /// Mongolia
         /// </summary>
-        MN,
+        MN = 7778,
         /// <summary>
         /// Montenegro
         /// </summary>
-        ME,
+        ME = 7769,
         /// <summary>
         /// Montserrat
         /// </summary>
-        MS,
+        MS = 7783,
         /// <summary>
         /// Morocco
         /// </summary>
-        MA,
+        MA = 7765,
         /// <summary>
         /// Mozambique
         /// </summary>
-        MZ,
+        MZ = 7790,
         /// <summary>
         /// Myanmar
         /// </summary>
-        MM,
+        MM = 7777,
         /// <summary>
         /// Namibia
         /// </summary>
-        NA,
+        NA = 7865,
         /// <summary>
         /// Nauru
         /// </summary>
-        NR,
+        NR = 7882,
         /// <summary>
         /// Nepal
         /// </summary>
-        NP,
+        NP = 7880,
         /// <summary>
         /// Netherlands
         /// </summary>
-        NL,
+        NL = 7876,
         /// <summary>
         /// New Caledonia
         /// </summary>
-        NC,
+        NC = 7867,
         /// <summary>
         /// New Zealand
         /// </summary>
-        NZ,
+        NZ = 7890,
         /// <summary>
         /// Nicaragua
         /// </summary>
-        NI,
+        NI = 7873,
         /// <summary>
         /// Niger
         /// </summary>
-        NE,
+        NE = 7869,
         /// <summary>
         /// Nigeria
         /// </summary>
-        NG,
+        NG = 7871,
         /// <summary>
         /// Niue
         /// </summary>
-        NU,
+        NU = 7885,
         /// <summary>
         /// Norfolk Island
         /// </summary>
-        NF,
+        NF = 7870,
         /// <summary>
         /// Northern Mariana Islands
         /// </summary>
-        MP,
+        MP = 7780,
         /// <summary>
         /// Norway
         /// </summary>
-        NO,
+        NO = 7879,
         /// <summary>
         /// Oman
         /// </summary>
-        OM,
+        OM = 7977,
         /// <summary>
         /// Pakistan
         /// </summary>
-        PK,
+        PK = 8075,
         /// <summary>
         /// Palau
         /// </summary>
-        PW,
+        PW = 8087,
         /// <summary>
         /// Palestine
         /// </summary>
-        PS,
+        PS = 8083,
         /// <summary>
         /// Panama
         /// </summary>
-        PA,
+        PA = 8065,
         /// <summary>
         /// Papua New Guinea
         /// </summary>
-        PG,
+        PG = 8071,
         /// <summary>
         /// Paraguay
         /// </summary>
-        PY,
+        PY = 8089,
         /// <summary>
         /// Peru
         /// </summary>
-        PE,
+        PE = 8069,
         /// <summary>
         /// Philippines
         /// </summary>
-        PH,
+        PH = 8072,
         /// <summary>
         /// Pitcairn
         /// </summary>
-        PN,
+        PN = 8078,
         /// <summary>
         /// Poland
         /// </summary>
-        PL,
+        PL = 8076,
         /// <summary>
         /// Portugal
         /// </summary>
-        PT,
+        PT = 8084,
         /// <summary>
         /// Puerto Rico
         /// </summary>
-        PR,
+        PR = 8082,
         /// <summary>
         /// Qatar
         /// </summary>
-        QA,
+        QA = 8165,
         /// <summary>
         /// Reunion
         /// </summary>
-        RE,
+        RE = 8269,
         /// <summary>
         /// Romania
         /// </summary>
-        RO,
+        RO = 8279,
         /// <summary>
         /// Russian Federation
         /// </summary>
-        RU,
+        RU = 8285,
         /// <summary>
         /// Rwanda
         /// </summary>
-        RW,
+        RW = 8287,
         /// <summary>
         /// Saint Barthélemy
         /// </summary>
-        BL,
+        BL = 6676,
         /// <summary>
         /// Saint Helena
         /// </summary>
-        SH,
+        SH = 8372,
         /// <summary>
         /// Saint Kitts and Nevis
         /// </summary>
-        KN,
+        KN = 7578,
         /// <summary>
         /// Saint Lucia
         /// </summary>
-        LC,
+        LC = 7667,
         /// <summary>
         /// Saint Martin (French part)
         /// </summary>
-        MF,
+        MF = 7770,
         /// <summary>
         /// Saint Pierre and Miquelon
         /// </summary>
-        PM,
+        PM = 8077,
         /// <summary>
         /// Saint Vincent and the Grenadines
         /// </summary>
-        VC,
+        VC = 8667,
         /// <summary>
         /// Samoa
         /// </summary>
-        WS,
+        WS = 8783,
         /// <summary>
         /// San Marino
         /// </summary>
-        SM,
+        SM = 8377,
         /// <summary>
         /// Sao Tome and Principe
         /// </summary>
-        ST,
+        ST = 8384,
         /// <summary>
         /// Saudi Arabia
         /// </summary>
-        SA,
+        SA = 8365,
         /// <summary>
         /// Senegal
         /// </summary>
-        SN,
+        SN = 8378,
         /// <summary>
         /// Serbia
         /// </summary>
-        RS,
+        RS = 8283,
         /// <summary>
         /// Seychelles
         /// </summary>
-        SC,
+        SC = 8367,
         /// <summary>
         /// Sierra Leone
         /// </summary>
-        SL,
+        SL = 8376,
         /// <summary>
         /// Singapore
         /// </summary>
-        SG,
+        SG = 8371,
         /// <summary>
         /// Sint Maarten (Dutch part)
         /// </summary>
-        SX,
+        SX = 8388,
         /// <summary>
         /// Slovakia
         /// </summary>
-        SK,
+        SK = 8375,
         /// <summary>
         /// Slovenia
         /// </summary>
-        SI,
+        SI = 8373,
         /// <summary>
         /// Solomon Islands
         /// </summary>
-        SB,
+        SB = 8366,
         /// <summary>
         /// Somalia
         /// </summary>
-        SO,
+        SO = 8379,
         /// <summary>
         /// South Africa
         /// </summary>
-        ZA,
+        ZA = 9065,
         /// <summary>
         /// South Georgia and South Sandwich Islands
         /// </summary>
-        GS,
+        GS = 7183,
         /// <summary>
         /// South Sudan
         /// </summary>
-        SS,
+        SS = 8383,
         /// <summary>
         /// Spain
         /// </summary>
-        ES,
+        ES = 6983,
         /// <summary>
         /// Sri Lanka
         /// </summary>
-        LK,
+        LK = 7675,
         /// <summary>
         /// Sudan
         /// </summary>
-        SD,
+        SD = 8368,
         /// <summary>
         /// Suriname
         /// </summary>
-        SR,
+        SR = 8382,
         /// <summary>
         /// Svalbard and Jan Mayen Islands
         /// </summary>
-        SJ,
+        SJ = 8374,
         /// <summary>
         /// Swaziland
         /// </summary>
-        SZ,
+        SZ = 8390,
         /// <summary>
         /// Sweden
         /// </summary>
-        SE,
+        SE = 8369,
         /// <summary>
         /// Switzerland
         /// </summary>
-        CH,
+        CH = 6772,
         /// <summary>
         /// Syria
         /// </summary>
-        SY,
+        SY = 8389,
         /// <summary>
         /// Taiwan
         /// </summary>
-        TW,
+        TW = 8487,
         /// <summary>
         /// Tajikistan
         /// </summary>
-        TJ,
+        TJ = 8474,
         /// <summary>
         /// Tanzania
         /// </summary>
-        TZ,
+        TZ = 8490,
         /// <summary>
         /// Thailand
         /// </summary>
-        TH,
+        TH = 8472,
         /// <summary>
         /// Timor-Leste
         /// </summary>
-        TL,
+        TL = 8476,
         /// <summary>
         /// Togo
         /// </summary>
-        TG,
+        TG = 8471,
         /// <summary>
         /// Tokelau
         /// </summary>
-        TK,
+        TK = 8475,
         /// <summary>
         /// Tonga
         /// </summary>
-        TO,
+        TO = 8479,
         /// <summary>
         /// Trinidad and Tobago
         /// </summary>
-        TT,
+        TT = 8484,
         /// <summary>
         /// Tunisia
         /// </summary>
-        TN,
+        TN = 8478,
         /// <summary>
         /// Turkey
         /// </summary>
-        TR,
+        TR = 8482,
         /// <summary>
         /// Turkmenistan
         /// </summary>
-        TM,
+        TM = 8477,
         /// <summary>
         /// Turks and Caicos Islands
         /// </summary>
-        TC,
+        TC = 8467,
         /// <summary>
         /// Tuvalu
         /// </summary>
-        TV,
+        TV = 8486,
         /// <summary>
         /// Uganda
         /// </summary>
-        UG,
+        UG = 8571,
         /// <summary>
         /// Ukraine
         /// </summary>
-        UA,
+        UA = 8565,
         /// <summary>
         /// United Arab Emirates
         /// </summary>
-        AE,
+        AE = 6569,
         /// <summary>
         /// United Kingdom
         /// </summary>
-        GB,
+        GB = 7166,
         /// <summary>
         /// United States Minor Outlying Islands
         /// </summary>
-        UM,
+        UM = 8577,
         /// <summary>
         /// United States of America
         /// </summary>
-        US,
+        US = 8583,
         /// <summary>
         /// Uruguay
         /// </summary>
-        UY,
+        UY = 8589,
         /// <summary>
         /// Uzbekistan
         /// </summary>
-        UZ,
+        UZ = 8590,
         /// <summary>
         /// Vanuatu
         /// </summary>
-        VU,
+        VU = 8685,
         /// <summary>
         /// Vatican City
         /// </summary>
-        VA,
+        VA = 8665,
         /// <summary>
         /// Venezuela
         /// </summary>
-        VE,
+        VE = 8669,
         /// <summary>
         /// Vietnam
         /// </summary>
-        VN,
+        VN = 8678,
         /// <summary>
         /// Virgin Islands, British
         /// </summary>
-        VG,
+        VG = 8671,
         /// <summary>
         /// Virgin Islands, U.S.
         /// </summary>
-        VI,
+        VI = 8673,
         /// <summary>
         /// Wallis and Futuna Islands
         /// </summary>
-        WF,
+        WF = 8770,
         /// <summary>
         /// Western Sahara
         /// </summary>
-        EH,
+        EH = 6972,
         /// <summary>
         /// Yemen
         /// </summary>
-        YE,
+        YE = 8969,
         /// <summary>
         /// Zambia
         /// </summary>
-        ZM,
+        ZM = 9077,
         /// <summary>
         /// Zimbabwe
         /// </summary>


### PR DESCRIPTION
Added explicit integer values to each Alpha2Code enum member, using a scheme where the value is the concatenation of the ASCII codes of the two-letter country code. This change enables easier conversion between enum values and their string representations.

- https://github.com/nager/Nager.Country/issues/49