### PR TITLE
Add Hindi translations for countries

### DIFF
--- a/src/Nager.Country.Translation/CountryTranslations/AfghanistanCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/AfghanistanCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Afganistan"),
             new TranslationInfo(LanguageCode.FR, "Afghanistan"),
             new TranslationInfo(LanguageCode.HE, "אפגניסטן"),
+            new TranslationInfo(LanguageCode.HI, "अफ़ग़ानिस्तान"),
             new TranslationInfo(LanguageCode.HR, "Afganistan"),
             new TranslationInfo(LanguageCode.HU, "Afganisztán"),
             new TranslationInfo(LanguageCode.HY, "Աֆղանստան"),

--- a/src/Nager.Country.Translation/CountryTranslations/AlandIslandsCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/AlandIslandsCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Ahvenanmaa"),
             new TranslationInfo(LanguageCode.FR, "Åland"),
             new TranslationInfo(LanguageCode.HE, "איי אולנד"),
+            new TranslationInfo(LanguageCode.HI, "ऑलैंड द्वीपसमूह"),
             new TranslationInfo(LanguageCode.HR, "Ålandski otoci"),
             new TranslationInfo(LanguageCode.HU, "Åland"),
             new TranslationInfo(LanguageCode.HY, "Ալանդյան կղզիներ"),

--- a/src/Nager.Country.Translation/CountryTranslations/AlbaniaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/AlbaniaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Albania"),
             new TranslationInfo(LanguageCode.FR, "Albanie"),
             new TranslationInfo(LanguageCode.HE, "אלבניה"),
+            new TranslationInfo(LanguageCode.HI, "अल्बानिया"),
             new TranslationInfo(LanguageCode.HR, "Albanija"),
             new TranslationInfo(LanguageCode.HU, "Albánia"),
             new TranslationInfo(LanguageCode.HY, "Ալբանիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/AlgeriaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/AlgeriaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Algeria"),
             new TranslationInfo(LanguageCode.FR, "Algérie"),
             new TranslationInfo(LanguageCode.HE, "אלג׳יריה"),
+            new TranslationInfo(LanguageCode.HI, "अल्जीरिया"),
             new TranslationInfo(LanguageCode.HR, "Alžir"),
             new TranslationInfo(LanguageCode.HU, "Algéria"),
             new TranslationInfo(LanguageCode.HY, "Ալժիր"),

--- a/src/Nager.Country.Translation/CountryTranslations/AmericanSamoaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/AmericanSamoaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Amerikan Samoa"),
             new TranslationInfo(LanguageCode.FR, "Samoa américaine"),
             new TranslationInfo(LanguageCode.HE, "סמואה האמריקנית"),
+            new TranslationInfo(LanguageCode.HI, "अमेरिकी समोआ"),
             new TranslationInfo(LanguageCode.HR, "Američka Samoa"),
             new TranslationInfo(LanguageCode.HU, "Amerikai Szamoa"),
             new TranslationInfo(LanguageCode.HY, "Ամերիկյան Սամոա"),

--- a/src/Nager.Country.Translation/CountryTranslations/AndorraCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/AndorraCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Andorra"),
             new TranslationInfo(LanguageCode.FR, "Andorre"),
             new TranslationInfo(LanguageCode.HE, "אנדורה"),
+            new TranslationInfo(LanguageCode.HI, "अन्डोरा"),
             new TranslationInfo(LanguageCode.HR, "Andora"),
             new TranslationInfo(LanguageCode.HU, "Andorra"),
             new TranslationInfo(LanguageCode.HY, "Անդորրա"),

--- a/src/Nager.Country.Translation/CountryTranslations/AngolaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/AngolaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Angola"),
             new TranslationInfo(LanguageCode.FR, "Angola"),
             new TranslationInfo(LanguageCode.HE, "אנגולה"),
+            new TranslationInfo(LanguageCode.HI, "अंगोला"),
             new TranslationInfo(LanguageCode.HR, "Angola"),
             new TranslationInfo(LanguageCode.HU, "Angola"),
             new TranslationInfo(LanguageCode.HY, "Անգոլա"),

--- a/src/Nager.Country.Translation/CountryTranslations/AnguillaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/AnguillaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Anguilla"),
             new TranslationInfo(LanguageCode.FR, "Anguilla"),
             new TranslationInfo(LanguageCode.HE, "אנגילה"),
+            new TranslationInfo(LanguageCode.HI, "एंगुइला"),
             new TranslationInfo(LanguageCode.HR, "Angvila"),
             new TranslationInfo(LanguageCode.HU, "Anguilla"),
             new TranslationInfo(LanguageCode.HY, "Անգուիլա"),

--- a/src/Nager.Country.Translation/CountryTranslations/AntarcticaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/AntarcticaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Antarktis"),
             new TranslationInfo(LanguageCode.FR, "Antarctique"),
             new TranslationInfo(LanguageCode.HE, "אנטארקטיקה"),
+            new TranslationInfo(LanguageCode.HI, "अंटार्कटिका"),
             new TranslationInfo(LanguageCode.HR, "Antarktika"),
             new TranslationInfo(LanguageCode.HU, "Antarktisz"),
             new TranslationInfo(LanguageCode.HY, "Անտարկտիդա"),

--- a/src/Nager.Country.Translation/CountryTranslations/AntiguaAndBarbudaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/AntiguaAndBarbudaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Antigua ja Barbuda"),
             new TranslationInfo(LanguageCode.FR, "Antigua et Barbuda"),
             new TranslationInfo(LanguageCode.HE, "אנטיגואה וברבודה"),
+            new TranslationInfo(LanguageCode.HI, "एंटीगुआ और बारबूडा"),
             new TranslationInfo(LanguageCode.HR, "Antigva i Barbuda"),
             new TranslationInfo(LanguageCode.HU, "Antigua és Barbuda"),
             new TranslationInfo(LanguageCode.HY, "Անտիգուա և Բարբուդա"),

--- a/src/Nager.Country.Translation/CountryTranslations/ArgentinaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/ArgentinaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Argentiina"),
             new TranslationInfo(LanguageCode.FR, "Argentine"),
             new TranslationInfo(LanguageCode.HE, "ארגנטינה"),
+            new TranslationInfo(LanguageCode.HI, "अर्जेंटीना"),
             new TranslationInfo(LanguageCode.HR, "Argentina"),
             new TranslationInfo(LanguageCode.HU, "Argentína"),
             new TranslationInfo(LanguageCode.HY, "Արգենտինա"),

--- a/src/Nager.Country.Translation/CountryTranslations/ArmeniaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/ArmeniaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Armenia"),
             new TranslationInfo(LanguageCode.FR, "Arménie"),
             new TranslationInfo(LanguageCode.HE, "ארמניה"),
+            new TranslationInfo(LanguageCode.HI, "आर्मेनिया"),
             new TranslationInfo(LanguageCode.HR, "Armenija"),
             new TranslationInfo(LanguageCode.HU, "Örményország"),
             new TranslationInfo(LanguageCode.HY, "Հայաստան"),

--- a/src/Nager.Country.Translation/CountryTranslations/ArubaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/ArubaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Aruba"),
             new TranslationInfo(LanguageCode.FR, "Aruba"),
             new TranslationInfo(LanguageCode.HE, "ארובה"),
+            new TranslationInfo(LanguageCode.HI, "अरूबा"),
             new TranslationInfo(LanguageCode.HR, "Aruba"),
             new TranslationInfo(LanguageCode.HU, "Aruba"),
             new TranslationInfo(LanguageCode.HY, "Արուբա"),

--- a/src/Nager.Country.Translation/CountryTranslations/AustraliaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/AustraliaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Australia"),
             new TranslationInfo(LanguageCode.FR, "Australie"),
             new TranslationInfo(LanguageCode.HE, "אוסטרליה"),
+            new TranslationInfo(LanguageCode.HI, "ऑस्ट्रेलिया"),
             new TranslationInfo(LanguageCode.HR, "Australija"),
             new TranslationInfo(LanguageCode.HU, "Ausztrália"),
             new TranslationInfo(LanguageCode.HY, "Ավստրալիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/AustriaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/AustriaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Itävalta"),
             new TranslationInfo(LanguageCode.FR, "Autriche"),
             new TranslationInfo(LanguageCode.HE, "אוסטריה"),
+            new TranslationInfo(LanguageCode.HI, "ऑस्ट्रिया"),
             new TranslationInfo(LanguageCode.HR, "Austrija"),
             new TranslationInfo(LanguageCode.HU, "Ausztria"),
             new TranslationInfo(LanguageCode.HY, "Ավստրիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/AzerbaijanCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/AzerbaijanCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Azerbaidžan"),
             new TranslationInfo(LanguageCode.FR, "Azerbaidjan"),
             new TranslationInfo(LanguageCode.HE, "אזרבייג׳ן"),
+            new TranslationInfo(LanguageCode.HI, "अज़रबैजान"),
             new TranslationInfo(LanguageCode.HR, "Azerbajdžan"),
             new TranslationInfo(LanguageCode.HU, "Azerbajdzsán"),
             new TranslationInfo(LanguageCode.HY, "Ադրբեջան"),

--- a/src/Nager.Country.Translation/CountryTranslations/BahamasCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/BahamasCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Bahama"),
             new TranslationInfo(LanguageCode.FR, "Bahamas"),
             new TranslationInfo(LanguageCode.HE, "איי בהאמה"),
+            new TranslationInfo(LanguageCode.HI, "बहामास"),
             new TranslationInfo(LanguageCode.HR, "Bahami"),
             new TranslationInfo(LanguageCode.HU, "Bahama-szigetek"),
             new TranslationInfo(LanguageCode.HY, "Բահամաներ"),

--- a/src/Nager.Country.Translation/CountryTranslations/BahrainCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/BahrainCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Bahrain"),
             new TranslationInfo(LanguageCode.FR, "Bahrein"),
             new TranslationInfo(LanguageCode.HE, "בחריין"),
+            new TranslationInfo(LanguageCode.HI, "बहरीन"),
             new TranslationInfo(LanguageCode.HR, "Bahrein"),
             new TranslationInfo(LanguageCode.HU, "Bahrein"),
             new TranslationInfo(LanguageCode.HY, "Բահրեյն"),

--- a/src/Nager.Country.Translation/CountryTranslations/BangladeshCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/BangladeshCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Bangladesh"),
             new TranslationInfo(LanguageCode.FR, "Bangladesh"),
             new TranslationInfo(LanguageCode.HE, "בנגלדש"),
+            new TranslationInfo(LanguageCode.HI, "बांग्लादेश"),
             new TranslationInfo(LanguageCode.HR, "Bangladeš"),
             new TranslationInfo(LanguageCode.HU, "Banglades"),
             new TranslationInfo(LanguageCode.HY, "Բանգլադեշ"),

--- a/src/Nager.Country.Translation/CountryTranslations/BarbadosCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/BarbadosCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Barbados"),
             new TranslationInfo(LanguageCode.FR, "Barbade"),
             new TranslationInfo(LanguageCode.HE, "ברבדוס"),
+            new TranslationInfo(LanguageCode.HI, "बारबाडोस"),
             new TranslationInfo(LanguageCode.HR, "Barbados"),
             new TranslationInfo(LanguageCode.HU, "Barbados"),
             new TranslationInfo(LanguageCode.HY, "Բարբադոս"),

--- a/src/Nager.Country.Translation/CountryTranslations/BelarusCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/BelarusCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Valko-Venäjä"),
             new TranslationInfo(LanguageCode.FR, "Bielorussie"),
             new TranslationInfo(LanguageCode.HE, "בלארוס"),
+            new TranslationInfo(LanguageCode.HI, "बेलारूस"),
             new TranslationInfo(LanguageCode.HR, "Bjelorusija"),
             new TranslationInfo(LanguageCode.HU, "Fehéroroszország"),
             new TranslationInfo(LanguageCode.HY, "Բելառուս"),

--- a/src/Nager.Country.Translation/CountryTranslations/BelgiumCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/BelgiumCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Belgia"),
             new TranslationInfo(LanguageCode.FR, "Belgique"),
             new TranslationInfo(LanguageCode.HE, "בלגיה"),
+            new TranslationInfo(LanguageCode.HI, "बेल्जियम"),
             new TranslationInfo(LanguageCode.HR, "Belgija"),
             new TranslationInfo(LanguageCode.HU, "Belgium"),
             new TranslationInfo(LanguageCode.HY, "Բելգիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/BelizeCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/BelizeCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Belize"),
             new TranslationInfo(LanguageCode.FR, "Belize"),
             new TranslationInfo(LanguageCode.HE, "בליז"),
+            new TranslationInfo(LanguageCode.HI, "बेलीज़"),
             new TranslationInfo(LanguageCode.HR, "Belize"),
             new TranslationInfo(LanguageCode.HU, "Belize"),
             new TranslationInfo(LanguageCode.HY, "Բելիզ"),

--- a/src/Nager.Country.Translation/CountryTranslations/BeninCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/BeninCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Benin"),
             new TranslationInfo(LanguageCode.FR, "Bénin"),
             new TranslationInfo(LanguageCode.HE, "בנין"),
+            new TranslationInfo(LanguageCode.HI, "बेनिन"),
             new TranslationInfo(LanguageCode.HR, "Benin"),
             new TranslationInfo(LanguageCode.HU, "Benin"),
             new TranslationInfo(LanguageCode.HY, "Բենին"),

--- a/src/Nager.Country.Translation/CountryTranslations/BermudaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/BermudaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Bermuda"),
             new TranslationInfo(LanguageCode.FR, "Bermudes"),
             new TranslationInfo(LanguageCode.HE, "ברמודה"),
+            new TranslationInfo(LanguageCode.HI, "बरमूडा"),
             new TranslationInfo(LanguageCode.HR, "Bermudi"),
             new TranslationInfo(LanguageCode.HU, "Bermuda"),
             new TranslationInfo(LanguageCode.HY, "Բերմուդներ"),

--- a/src/Nager.Country.Translation/CountryTranslations/BhutanCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/BhutanCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Bhutan"),
             new TranslationInfo(LanguageCode.FR, "Bhoutan"),
             new TranslationInfo(LanguageCode.HE, "בהוטן"),
+            new TranslationInfo(LanguageCode.HI, "भूटान"),
             new TranslationInfo(LanguageCode.HR, "Butan"),
             new TranslationInfo(LanguageCode.HU, "Bhután"),
             new TranslationInfo(LanguageCode.HY, "Բութան"),

--- a/src/Nager.Country.Translation/CountryTranslations/BoliviaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/BoliviaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Bolivia"),
             new TranslationInfo(LanguageCode.FR, "Bolivie"),
             new TranslationInfo(LanguageCode.HE, "בוליביה"),
+            new TranslationInfo(LanguageCode.HI, "बोलीविया"),
             new TranslationInfo(LanguageCode.HR, "Bolivija"),
             new TranslationInfo(LanguageCode.HU, "Bolívia"),
             new TranslationInfo(LanguageCode.HY, "Բոլիվիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/BosniaandHerzegovinaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/BosniaandHerzegovinaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Bosnia ja Hertsegovina"),
             new TranslationInfo(LanguageCode.FR, "Bosnie-Herzégovine"),
             new TranslationInfo(LanguageCode.HE, "בוסניה והרצגובינה"),
+            new TranslationInfo(LanguageCode.HI, "बोस्निया और हर्ज़ेगोविना"),
             new TranslationInfo(LanguageCode.HR, "Bosna i Hercegovina"),
             new TranslationInfo(LanguageCode.HU, "Bosznia-Hercegovina"),
             new TranslationInfo(LanguageCode.HY, "Բոսնիա և Հերցեգովինա"),

--- a/src/Nager.Country.Translation/CountryTranslations/BotswanaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/BotswanaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Botswana"),
             new TranslationInfo(LanguageCode.FR, "Botswana"),
             new TranslationInfo(LanguageCode.HE, "בוצוואנה"),
+            new TranslationInfo(LanguageCode.HI, "बोत्सवाना"),
             new TranslationInfo(LanguageCode.HR, "Bocvana"),
             new TranslationInfo(LanguageCode.HU, "Botswana"),
             new TranslationInfo(LanguageCode.HY, "Բոթսվանա"),

--- a/src/Nager.Country.Translation/CountryTranslations/BouvetIslandCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/BouvetIslandCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Bouvet’nsaari"),
             new TranslationInfo(LanguageCode.FR, "Île Bouvet"),
             new TranslationInfo(LanguageCode.HE, "איי בובה"),
+            new TranslationInfo(LanguageCode.HI, "बुवे द्वीप"),
             new TranslationInfo(LanguageCode.HR, "Otok Bouvet"),
             new TranslationInfo(LanguageCode.HU, "Bouvet-sziget"),
             new TranslationInfo(LanguageCode.HY, "Բուվե կղզի"),

--- a/src/Nager.Country.Translation/CountryTranslations/BrazilCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/BrazilCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Brasilia"),
             new TranslationInfo(LanguageCode.FR, "Brésil"),
             new TranslationInfo(LanguageCode.HE, "ברזיל"),
+            new TranslationInfo(LanguageCode.HI, "ब्राज़ील"),
             new TranslationInfo(LanguageCode.HR, "Brazil"),
             new TranslationInfo(LanguageCode.HU, "Brazília"),
             new TranslationInfo(LanguageCode.HY, "Բրազիլիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/BritishIndianOceanTerritoryCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/BritishIndianOceanTerritoryCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Brittiläinen Intian valtameren alue"),
             new TranslationInfo(LanguageCode.FR, "Océan Indien Britannique"),
             new TranslationInfo(LanguageCode.HE, "הטריטוריה הבריטית באוקיינוס ההודי"),
+            new TranslationInfo(LanguageCode.HI, "ब्रिटिश हिंद महासागर क्षेत्र"),
             new TranslationInfo(LanguageCode.HR, "Britanski Indijskooceanski teritorij"),
             new TranslationInfo(LanguageCode.HU, "Brit Indiai-óceáni Terület"),
             new TranslationInfo(LanguageCode.HY, "Բրիտանական Տարածք Հնդկական Օվկիանոսում"),

--- a/src/Nager.Country.Translation/CountryTranslations/BritishVirginIslandsCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/BritishVirginIslandsCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Brittiläiset Neitsytsaaret"),
             new TranslationInfo(LanguageCode.FR, "Îles vierges britanniques"),
             new TranslationInfo(LanguageCode.HE, "איי הבתולה הבריטיים"),
+            new TranslationInfo(LanguageCode.HI, "ब्रिटिश वर्जिन द्वीपसमूह"),
             new TranslationInfo(LanguageCode.HR, "Britanski Djevičanski otoci"),
             new TranslationInfo(LanguageCode.HU, "Brit Virgin-szigetek"),
             new TranslationInfo(LanguageCode.HY, "Բրիտանական Վիրջինյան կղզիներ"),

--- a/src/Nager.Country.Translation/CountryTranslations/BruneiCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/BruneiCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Brunei"),
             new TranslationInfo(LanguageCode.FR, "Brunei Darussalam"),
             new TranslationInfo(LanguageCode.HE, "ברוניי"),
+            new TranslationInfo(LanguageCode.HI, "ब्रुनेई"),
             new TranslationInfo(LanguageCode.HR, "Brunej"),
             new TranslationInfo(LanguageCode.HU, "Brunei"),
             new TranslationInfo(LanguageCode.HY, "Բրունեյ"),

--- a/src/Nager.Country.Translation/CountryTranslations/BulgariaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/BulgariaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Bulgaria"),
             new TranslationInfo(LanguageCode.FR, "Bulgarie"),
             new TranslationInfo(LanguageCode.HE, "בולגריה"),
+            new TranslationInfo(LanguageCode.HI, "बुल्गारिया"),
             new TranslationInfo(LanguageCode.HR, "Bugarska"),
             new TranslationInfo(LanguageCode.HU, "Bulgária"),
             new TranslationInfo(LanguageCode.HY, "Բուլղարիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/BurkinaFasoCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/BurkinaFasoCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Burkina Faso"),
             new TranslationInfo(LanguageCode.FR, "Burkina Faso"),
             new TranslationInfo(LanguageCode.HE, "בורקינה פאסו"),
+            new TranslationInfo(LanguageCode.HI, "बुर्किना फ़ासो"),
             new TranslationInfo(LanguageCode.HR, "Burkina Faso"),
             new TranslationInfo(LanguageCode.HU, "Burkina Faso"),
             new TranslationInfo(LanguageCode.HY, "Բուրկինա Ֆասո"),

--- a/src/Nager.Country.Translation/CountryTranslations/BurundiCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/BurundiCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Burundi"),
             new TranslationInfo(LanguageCode.FR, "Burundi"),
             new TranslationInfo(LanguageCode.HE, "בורונדי"),
+            new TranslationInfo(LanguageCode.HI, "बुरुंडी"),
             new TranslationInfo(LanguageCode.HR, "Burundi"),
             new TranslationInfo(LanguageCode.HU, "Burundi"),
             new TranslationInfo(LanguageCode.HY, "Բուրունդի"),

--- a/src/Nager.Country.Translation/CountryTranslations/CambodiaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/CambodiaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Kambodža"),
             new TranslationInfo(LanguageCode.FR, "Cambodge"),
             new TranslationInfo(LanguageCode.HE, "קמבודיה"),
+            new TranslationInfo(LanguageCode.HI, "कंबोडिया"),
             new TranslationInfo(LanguageCode.HR, "Kambodža"),
             new TranslationInfo(LanguageCode.HU, "Kambodzsa"),
             new TranslationInfo(LanguageCode.HY, "Կամբոջա"),

--- a/src/Nager.Country.Translation/CountryTranslations/CameroonCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/CameroonCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Kamerun"),
             new TranslationInfo(LanguageCode.FR, "Cameroun"),
             new TranslationInfo(LanguageCode.HE, "קמרון"),
+            new TranslationInfo(LanguageCode.HI, "कैमरून"),
             new TranslationInfo(LanguageCode.HR, "Kamerun"),
             new TranslationInfo(LanguageCode.HU, "Kamerun"),
             new TranslationInfo(LanguageCode.HY, "Կամերուն"),

--- a/src/Nager.Country.Translation/CountryTranslations/CanadaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/CanadaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Kanada"),
             new TranslationInfo(LanguageCode.FR, "Canada"),
             new TranslationInfo(LanguageCode.HE, "קנדה"),
+            new TranslationInfo(LanguageCode.HI, "कनाडा"),
             new TranslationInfo(LanguageCode.HR, "Kanada"),
             new TranslationInfo(LanguageCode.HU, "Kanada"),
             new TranslationInfo(LanguageCode.HY, "Կանադա"),

--- a/src/Nager.Country.Translation/CountryTranslations/CapeVerdeCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/CapeVerdeCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Kap Verde"),
             new TranslationInfo(LanguageCode.FR, "Cap-Vert"),
             new TranslationInfo(LanguageCode.HE, "כף ורדה"),
+            new TranslationInfo(LanguageCode.HI, "केप वर्डे"),
             new TranslationInfo(LanguageCode.HR, "Zelenortska Republika"),
             new TranslationInfo(LanguageCode.HU, "Zöld-foki Köztársaság"),
             new TranslationInfo(LanguageCode.HY, "Կաբո Վերդե"),

--- a/src/Nager.Country.Translation/CountryTranslations/CaribbeanNetherlandsCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/CaribbeanNetherlandsCountryTranslation.cs
@@ -15,6 +15,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.ES, "Caribbean Netherlands"),
             new TranslationInfo(LanguageCode.IT, "Caribbean Netherlands"),
 			new TranslationInfo(LanguageCode.KO, "네덜란드령 카리브"),
+            new TranslationInfo(LanguageCode.HI, "कैरिबियन नीदरलैंड"),
 		};
         
     }

--- a/src/Nager.Country.Translation/CountryTranslations/CaribbeanNetherlandsCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/CaribbeanNetherlandsCountryTranslation.cs
@@ -8,15 +8,15 @@ namespace Nager.Country.Translation.CountryTranslations
         /// <inheritdoc/>
         public TranslationInfo[] Translations => new[]
         {
-            new TranslationInfo(LanguageCode.EN, "Caribbean Netherlands"),
             new TranslationInfo(LanguageCode.DE, "Caribbean Netherlands"),
-            new TranslationInfo(LanguageCode.NL, "Caribisch Nederland"),
-            new TranslationInfo(LanguageCode.FR, "Caribbean Netherlands"),
+            new TranslationInfo(LanguageCode.EN, "Caribbean Netherlands"),
             new TranslationInfo(LanguageCode.ES, "Caribbean Netherlands"),
-            new TranslationInfo(LanguageCode.IT, "Caribbean Netherlands"),
-			new TranslationInfo(LanguageCode.KO, "네덜란드령 카리브"),
+            new TranslationInfo(LanguageCode.FR, "Caribbean Netherlands"),
             new TranslationInfo(LanguageCode.HI, "कैरिबियन नीदरलैंड"),
-		};
-        
+            new TranslationInfo(LanguageCode.IT, "Caribbean Netherlands"),
+            new TranslationInfo(LanguageCode.KO, "네덜란드령 카리브"),
+            new TranslationInfo(LanguageCode.NL, "Caribisch Nederland"),
+        };
+
     }
 }

--- a/src/Nager.Country.Translation/CountryTranslations/CaymanIslandsCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/CaymanIslandsCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Caymansaaret"),
             new TranslationInfo(LanguageCode.FR, "Caïmanes"),
             new TranslationInfo(LanguageCode.HE, "איי קיימן"),
+            new TranslationInfo(LanguageCode.HI, "केमैन द्वीपसमूह"),
             new TranslationInfo(LanguageCode.HR, "Kajmanski otoci"),
             new TranslationInfo(LanguageCode.HU, "Kajmán-szigetek"),
             new TranslationInfo(LanguageCode.HY, "Կայմանյան կղզիներ"),

--- a/src/Nager.Country.Translation/CountryTranslations/CentralAfricanRepublicCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/CentralAfricanRepublicCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Keski-Afrikan tasavalta"),
             new TranslationInfo(LanguageCode.FR, "Centrafricaine, République"),
             new TranslationInfo(LanguageCode.HE, "הרפובליקה של מרכז אפריקה"),
+            new TranslationInfo(LanguageCode.HI, "मध्य अफ़्रीकी गणराज्य"),
             new TranslationInfo(LanguageCode.HR, "Srednjoafrička Republika"),
             new TranslationInfo(LanguageCode.HU, "Közép-afrikai Köztársaság"),
             new TranslationInfo(LanguageCode.HY, "Կենտրոնական Աֆրիկյան Հանրապետություն"),

--- a/src/Nager.Country.Translation/CountryTranslations/ChadCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/ChadCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Tšad"),
             new TranslationInfo(LanguageCode.FR, "Tchad"),
             new TranslationInfo(LanguageCode.HE, "צ׳אד"),
+            new TranslationInfo(LanguageCode.HI, "चाड"),
             new TranslationInfo(LanguageCode.HR, "Čad"),
             new TranslationInfo(LanguageCode.HU, "Csád"),
             new TranslationInfo(LanguageCode.HY, "Չադ"),

--- a/src/Nager.Country.Translation/CountryTranslations/ChileCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/ChileCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Chile"),
             new TranslationInfo(LanguageCode.FR, "Chili"),
             new TranslationInfo(LanguageCode.HE, "צ׳ילה"),
+            new TranslationInfo(LanguageCode.HI, "चिली"),
             new TranslationInfo(LanguageCode.HR, "Čile"),
             new TranslationInfo(LanguageCode.HU, "Chile"),
             new TranslationInfo(LanguageCode.HY, "Չիլի"),

--- a/src/Nager.Country.Translation/CountryTranslations/ChinaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/ChinaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Kiina"),
             new TranslationInfo(LanguageCode.FR, "Chine"),
             new TranslationInfo(LanguageCode.HE, "סין"),
+            new TranslationInfo(LanguageCode.HI, "चीन"),
             new TranslationInfo(LanguageCode.HR, "Kina"),
             new TranslationInfo(LanguageCode.HU, "Kína"),
             new TranslationInfo(LanguageCode.HY, "Չինաստան"),

--- a/src/Nager.Country.Translation/CountryTranslations/ChristmasIslandCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/ChristmasIslandCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Joulusaari"),
             new TranslationInfo(LanguageCode.FR, "Île Christmas"),
             new TranslationInfo(LanguageCode.HE, "האי כריסטמס"),
+            new TranslationInfo(LanguageCode.HI, "क्रिसमस द्वीप"),
             new TranslationInfo(LanguageCode.HR, "Božićni otok"),
             new TranslationInfo(LanguageCode.HU, "Karácsony-sziget"),
             new TranslationInfo(LanguageCode.HY, "Սուրբ Ծննդյան կղզի"),

--- a/src/Nager.Country.Translation/CountryTranslations/CocosIslandsCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/CocosIslandsCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Kookossaaret"),
             new TranslationInfo(LanguageCode.FR, "Cocos"),
             new TranslationInfo(LanguageCode.HE, "איי קוקוס (קילינג)"),
+            new TranslationInfo(LanguageCode.HI, "कोकोस द्वीपसमूह"),
             new TranslationInfo(LanguageCode.HR, "Kokosovi (Keelingovi) otoci"),
             new TranslationInfo(LanguageCode.HU, "Kókusz (Keeling)-szigetek"),
             new TranslationInfo(LanguageCode.HY, "Կոկոսյան (Քիլինգ) կղզիներ"),

--- a/src/Nager.Country.Translation/CountryTranslations/ColombiaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/ColombiaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Kolumbia"),
             new TranslationInfo(LanguageCode.FR, "Colombie"),
             new TranslationInfo(LanguageCode.HE, "קולומביה"),
+            new TranslationInfo(LanguageCode.HI, "कोलंबिया"),
             new TranslationInfo(LanguageCode.HR, "Kolumbija"),
             new TranslationInfo(LanguageCode.HU, "Kolumbia"),
             new TranslationInfo(LanguageCode.HY, "Կոլումբիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/ComorosCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/ComorosCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Komorit"),
             new TranslationInfo(LanguageCode.FR, "Comores"),
             new TranslationInfo(LanguageCode.HE, "קומורו"),
+            new TranslationInfo(LanguageCode.HI, "कोमोरोस"),
             new TranslationInfo(LanguageCode.HR, "Komori"),
             new TranslationInfo(LanguageCode.HU, "Comore-szigetek"),
             new TranslationInfo(LanguageCode.HY, "Կոմորյան կղզիներ"),

--- a/src/Nager.Country.Translation/CountryTranslations/CongoCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/CongoCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Kongon demokraattinen tasavalta"),
             new TranslationInfo(LanguageCode.FR, "Congo, République démocratique"),
             new TranslationInfo(LanguageCode.HE, "קונגו-קינשאסה"),
+            new TranslationInfo(LanguageCode.HI, "कांगो लोकतांत्रिक गणराज्य"),
             new TranslationInfo(LanguageCode.HR, "Kongo-Kinshasa"),
             new TranslationInfo(LanguageCode.HU, "Kongói Demokratikus Köztársaság"),
             new TranslationInfo(LanguageCode.HY, "Կոնգո-Կինշասա"),

--- a/src/Nager.Country.Translation/CountryTranslations/CookIslandsCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/CookIslandsCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Cookinsaaret"),
             new TranslationInfo(LanguageCode.FR, "Îles Cook"),
             new TranslationInfo(LanguageCode.HE, "איי קוק"),
+            new TranslationInfo(LanguageCode.HI, "कुक द्वीपसमूह"),
             new TranslationInfo(LanguageCode.HR, "Cookovi Otoci"),
             new TranslationInfo(LanguageCode.HU, "Cook-szigetek"),
             new TranslationInfo(LanguageCode.HY, "Կուկի կղզիներ"),

--- a/src/Nager.Country.Translation/CountryTranslations/CostaRicaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/CostaRicaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Costa Rica"),
             new TranslationInfo(LanguageCode.FR, "Costa Rica"),
             new TranslationInfo(LanguageCode.HE, "קוסטה ריקה"),
+            new TranslationInfo(LanguageCode.HI, "कोस्टा रिका"),
             new TranslationInfo(LanguageCode.HR, "Kostarika"),
             new TranslationInfo(LanguageCode.HU, "Costa Rica"),
             new TranslationInfo(LanguageCode.HY, "Կոստա Ռիկա"),

--- a/src/Nager.Country.Translation/CountryTranslations/CroatiaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/CroatiaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Kroatia"),
             new TranslationInfo(LanguageCode.FR, "Croatie"),
             new TranslationInfo(LanguageCode.HE, "קרואטיה"),
+            new TranslationInfo(LanguageCode.HI, "क्रोएशिया"),
             new TranslationInfo(LanguageCode.HR, "Hrvatska"),
             new TranslationInfo(LanguageCode.HU, "Horvátország"),
             new TranslationInfo(LanguageCode.HY, "Խորվաթիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/CubaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/CubaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Kuuba"),
             new TranslationInfo(LanguageCode.FR, "Cuba"),
             new TranslationInfo(LanguageCode.HE, "קובה"),
+            new TranslationInfo(LanguageCode.HI, "क्यूबा"),
             new TranslationInfo(LanguageCode.HR, "Kuba"),
             new TranslationInfo(LanguageCode.HU, "Kuba"),
             new TranslationInfo(LanguageCode.HY, "Կուբա"),

--- a/src/Nager.Country.Translation/CountryTranslations/CuracaoCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/CuracaoCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Curaçao"),
             new TranslationInfo(LanguageCode.FR, "Curaçao"),
             new TranslationInfo(LanguageCode.HE, "קוראסאו"),
+            new TranslationInfo(LanguageCode.HI, "कुराकाओ"),
             new TranslationInfo(LanguageCode.HR, "Curaçao"),
             new TranslationInfo(LanguageCode.HU, "Curaçao"),
             new TranslationInfo(LanguageCode.HY, "Կյուրասաո"),

--- a/src/Nager.Country.Translation/CountryTranslations/CyprusCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/CyprusCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Kypros"),
             new TranslationInfo(LanguageCode.FR, "Chypre"),
             new TranslationInfo(LanguageCode.HE, "קפריסין"),
+            new TranslationInfo(LanguageCode.HI, "साइप्रस"),
             new TranslationInfo(LanguageCode.HR, "Cipar"),
             new TranslationInfo(LanguageCode.HU, "Ciprus"),
             new TranslationInfo(LanguageCode.HY, "Կիպրոս"),

--- a/src/Nager.Country.Translation/CountryTranslations/CzechRepublicCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/CzechRepublicCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Tšekki"),
             new TranslationInfo(LanguageCode.FR, "Tchéquie"),
             new TranslationInfo(LanguageCode.HE, "צ׳כיה"),
+            new TranslationInfo(LanguageCode.HI, "चेक गणराज्य"),
             new TranslationInfo(LanguageCode.HR, "Češka"),
             new TranslationInfo(LanguageCode.HU, "Csehország"),
             new TranslationInfo(LanguageCode.HY, "Չեխիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/DenmarkCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/DenmarkCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Tanska"),
             new TranslationInfo(LanguageCode.FR, "Danemark"),
             new TranslationInfo(LanguageCode.HE, "דנמרק"),
+            new TranslationInfo(LanguageCode.HI, "डेनमार्क"),
             new TranslationInfo(LanguageCode.HR, "Danska"),
             new TranslationInfo(LanguageCode.HU, "Dánia"),
             new TranslationInfo(LanguageCode.HY, "Դանիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/DjiboutiCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/DjiboutiCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Djibouti"),
             new TranslationInfo(LanguageCode.FR, "Djibouti"),
             new TranslationInfo(LanguageCode.HE, "ג׳יבוטי"),
+            new TranslationInfo(LanguageCode.HI, "जिबूती"),
             new TranslationInfo(LanguageCode.HR, "Džibuti"),
             new TranslationInfo(LanguageCode.HU, "Dzsibuti"),
             new TranslationInfo(LanguageCode.HY, "Ջիբութի"),

--- a/src/Nager.Country.Translation/CountryTranslations/DominicaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/DominicaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Dominica"),
             new TranslationInfo(LanguageCode.FR, "Dominique"),
             new TranslationInfo(LanguageCode.HE, "דומיניקה"),
+            new TranslationInfo(LanguageCode.HI, "डोमिनिका"),
             new TranslationInfo(LanguageCode.HR, "Dominika"),
             new TranslationInfo(LanguageCode.HU, "Dominikai Közösség"),
             new TranslationInfo(LanguageCode.HY, "Դոմինիկա"),

--- a/src/Nager.Country.Translation/CountryTranslations/DominicanRepublicCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/DominicanRepublicCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Dominikaaninen tasavalta"),
             new TranslationInfo(LanguageCode.FR, "République Dominicaine"),
             new TranslationInfo(LanguageCode.HE, "הרפובליקה הדומיניקנית"),
+            new TranslationInfo(LanguageCode.HI, "डोमिनिकन गणराज्य"),
             new TranslationInfo(LanguageCode.HR, "Dominikanska Republika"),
             new TranslationInfo(LanguageCode.HU, "Dominikai Köztársaság"),
             new TranslationInfo(LanguageCode.HY, "Դոմինիկյան Հանրապետություն"),

--- a/src/Nager.Country.Translation/CountryTranslations/EcuadorCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/EcuadorCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Ecuador"),
             new TranslationInfo(LanguageCode.FR, "Équateur"),
             new TranslationInfo(LanguageCode.HE, "אקוודור"),
+            new TranslationInfo(LanguageCode.HI, "इक्वाडोर"),
             new TranslationInfo(LanguageCode.HR, "Ekvador"),
             new TranslationInfo(LanguageCode.HU, "Ecuador"),
             new TranslationInfo(LanguageCode.HY, "Էկվադոր"),

--- a/src/Nager.Country.Translation/CountryTranslations/EgyptCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/EgyptCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Egypti"),
             new TranslationInfo(LanguageCode.FR, "Égypte"),
             new TranslationInfo(LanguageCode.HE, "מצרים"),
+            new TranslationInfo(LanguageCode.HI, "मिस्र"),
             new TranslationInfo(LanguageCode.HR, "Egipat"),
             new TranslationInfo(LanguageCode.HU, "Egyiptom"),
             new TranslationInfo(LanguageCode.HY, "Եգիպտոս"),

--- a/src/Nager.Country.Translation/CountryTranslations/ElSalvadorCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/ElSalvadorCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "El Salvador"),
             new TranslationInfo(LanguageCode.FR, "El Salvador"),
             new TranslationInfo(LanguageCode.HE, "אל סלבדור"),
+            new TranslationInfo(LanguageCode.HI, "अल साल्वाडोर"),
             new TranslationInfo(LanguageCode.HR, "Salvador"),
             new TranslationInfo(LanguageCode.HU, "Salvador"),
             new TranslationInfo(LanguageCode.HY, "Սալվադոր"),

--- a/src/Nager.Country.Translation/CountryTranslations/EquatorialGuineaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/EquatorialGuineaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Päiväntasaajan Guinea"),
             new TranslationInfo(LanguageCode.FR, "Guinée équatoriale"),
             new TranslationInfo(LanguageCode.HE, "גינאה המשוונית"),
+            new TranslationInfo(LanguageCode.HI, "भूमध्यरेखीय गिनी"),
             new TranslationInfo(LanguageCode.HR, "Ekvatorska Gvineja"),
             new TranslationInfo(LanguageCode.HU, "Egyenlítői-Guinea"),
             new TranslationInfo(LanguageCode.HY, "Հասարակածային Գվինեա"),

--- a/src/Nager.Country.Translation/CountryTranslations/EritreaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/EritreaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Eritrea"),
             new TranslationInfo(LanguageCode.FR, "Érythrée"),
             new TranslationInfo(LanguageCode.HE, "אריתריאה"),
+            new TranslationInfo(LanguageCode.HI, "इरिट्रिया"),
             new TranslationInfo(LanguageCode.HR, "Eritreja"),
             new TranslationInfo(LanguageCode.HU, "Eritrea"),
             new TranslationInfo(LanguageCode.HY, "Էրիթրեա"),

--- a/src/Nager.Country.Translation/CountryTranslations/EstoniaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/EstoniaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Viro"),
             new TranslationInfo(LanguageCode.FR, "Estonie"),
             new TranslationInfo(LanguageCode.HE, "אסטוניה"),
+            new TranslationInfo(LanguageCode.HI, "एस्टोनिया"),
             new TranslationInfo(LanguageCode.HR, "Estonija"),
             new TranslationInfo(LanguageCode.HU, "Észtország"),
             new TranslationInfo(LanguageCode.HY, "Էստոնիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/EswatiniCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/EswatiniCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Eswatini"),
             new TranslationInfo(LanguageCode.FR, "Eswatini"),
             new TranslationInfo(LanguageCode.HE, "אסוואטיני"),
+            new TranslationInfo(LanguageCode.HI, "एस्वातिनी"),
             new TranslationInfo(LanguageCode.HR, "Esvatini"),
             new TranslationInfo(LanguageCode.HU, "Eswatini"),
             new TranslationInfo(LanguageCode.HY, "Էսվատինի"),

--- a/src/Nager.Country.Translation/CountryTranslations/EthiopiaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/EthiopiaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Etiopia"),
             new TranslationInfo(LanguageCode.FR, "Éthiopie"),
             new TranslationInfo(LanguageCode.HE, "אתיופיה"),
+            new TranslationInfo(LanguageCode.HI, "इथियोपिया"),
             new TranslationInfo(LanguageCode.HR, "Etiopija"),
             new TranslationInfo(LanguageCode.HU, "Etiópia"),
             new TranslationInfo(LanguageCode.HY, "Եթովպիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/FalklandIslandsCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/FalklandIslandsCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Falklandinsaaret"),
             new TranslationInfo(LanguageCode.FR, "Îles Malouines"),
             new TranslationInfo(LanguageCode.HE, "איי פוקלנד"),
+            new TranslationInfo(LanguageCode.HI, "फ़ॉकलैंड द्वीपसमूह"),
             new TranslationInfo(LanguageCode.HR, "Falklandski otoci"),
             new TranslationInfo(LanguageCode.HU, "Falkland-szigetek"),
             new TranslationInfo(LanguageCode.HY, "Ֆոլքլենդյան կղզիներ"),

--- a/src/Nager.Country.Translation/CountryTranslations/FaroeIslandsCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/FaroeIslandsCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Färsaaret"),
             new TranslationInfo(LanguageCode.FR, "Îles Féroé"),
             new TranslationInfo(LanguageCode.HE, "איי פארו"),
+            new TranslationInfo(LanguageCode.HI, "फ़ैरो द्वीपसमूह"),
             new TranslationInfo(LanguageCode.HR, "Farski otoci"),
             new TranslationInfo(LanguageCode.HU, "Feröer"),
             new TranslationInfo(LanguageCode.HY, "Ֆարերյան կղզիներ"),

--- a/src/Nager.Country.Translation/CountryTranslations/FijiCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/FijiCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Fidži"),
             new TranslationInfo(LanguageCode.FR, "Fidji"),
             new TranslationInfo(LanguageCode.HE, "פיג׳י"),
+            new TranslationInfo(LanguageCode.HI, "फ़िजी"),
             new TranslationInfo(LanguageCode.HR, "Fidži"),
             new TranslationInfo(LanguageCode.HU, "Fidzsi-szigetek"),
             new TranslationInfo(LanguageCode.HY, "Ֆիջի"),

--- a/src/Nager.Country.Translation/CountryTranslations/FinlandCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/FinlandCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Suomi"),
             new TranslationInfo(LanguageCode.FR, "Finlande"),
             new TranslationInfo(LanguageCode.HE, "פינלנד"),
+            new TranslationInfo(LanguageCode.HI, "फ़िनलैंड"),
             new TranslationInfo(LanguageCode.HR, "Finska"),
             new TranslationInfo(LanguageCode.HU, "Finnország"),
             new TranslationInfo(LanguageCode.HY, "Ֆինլանդիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/FranceCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/FranceCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Ranska"),
             new TranslationInfo(LanguageCode.FR, "France"),
             new TranslationInfo(LanguageCode.HE, "צרפת"),
+            new TranslationInfo(LanguageCode.HI, "फ़्रांस"),
             new TranslationInfo(LanguageCode.HR, "Francuska"),
             new TranslationInfo(LanguageCode.HU, "Franciaország"),
             new TranslationInfo(LanguageCode.HY, "Ֆրանսիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/FrenchGuianaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/FrenchGuianaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Ranskan Guayana"),
             new TranslationInfo(LanguageCode.FR, "Guyane française"),
             new TranslationInfo(LanguageCode.HE, "גיאנה הצרפתית"),
+            new TranslationInfo(LanguageCode.HI, "फ्रेंच गयाना"),
             new TranslationInfo(LanguageCode.HR, "Francuska Gijana"),
             new TranslationInfo(LanguageCode.HU, "Francia Guyana"),
             new TranslationInfo(LanguageCode.HY, "Ֆրանսիական Գվիանա"),

--- a/src/Nager.Country.Translation/CountryTranslations/FrenchPolynesiaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/FrenchPolynesiaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Ranskan Polynesia"),
             new TranslationInfo(LanguageCode.FR, "Polynésie française"),
             new TranslationInfo(LanguageCode.HE, "פולינזיה הצרפתית"),
+            new TranslationInfo(LanguageCode.HI, "फ्रेंच पोलिनेशिया"),
             new TranslationInfo(LanguageCode.HR, "Francuska Polinezija"),
             new TranslationInfo(LanguageCode.HU, "Francia Polinézia"),
             new TranslationInfo(LanguageCode.HY, "Ֆրանսիական Պոլինեզիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/FrenchSouthernAndAntarcticLandsCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/FrenchSouthernAndAntarcticLandsCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Ranskan eteläiset alueet"),
             new TranslationInfo(LanguageCode.FR, "Terres australes françaises"),
             new TranslationInfo(LanguageCode.HE, "הטריטוריות הדרומיות של צרפת"),
+            new TranslationInfo(LanguageCode.HI, "फ्रेंच दक्षिणी और अंटार्कटिक भूमि"),
             new TranslationInfo(LanguageCode.HR, "Francuski južni i antarktički teritoriji"),
             new TranslationInfo(LanguageCode.HU, "Francia déli területek"),
             new TranslationInfo(LanguageCode.HY, "Ֆրանսիական Հարավային Տարածքներ"),

--- a/src/Nager.Country.Translation/CountryTranslations/GabonCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/GabonCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Gabon"),
             new TranslationInfo(LanguageCode.FR, "Gabon"),
             new TranslationInfo(LanguageCode.HE, "גבון"),
+            new TranslationInfo(LanguageCode.HI, "गैबॉन"),
             new TranslationInfo(LanguageCode.HR, "Gabon"),
             new TranslationInfo(LanguageCode.HU, "Gabon"),
             new TranslationInfo(LanguageCode.HY, "Գաբոն"),

--- a/src/Nager.Country.Translation/CountryTranslations/GambiaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/GambiaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Gambia"),
             new TranslationInfo(LanguageCode.FR, "Gambie"),
             new TranslationInfo(LanguageCode.HE, "גמביה"),
+            new TranslationInfo(LanguageCode.HI, "गांबिया"),
             new TranslationInfo(LanguageCode.HR, "Gambija"),
             new TranslationInfo(LanguageCode.HU, "Gambia"),
             new TranslationInfo(LanguageCode.HY, "Գամբիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/GeorgiaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/GeorgiaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Georgia"),
             new TranslationInfo(LanguageCode.FR, "Géorgie"),
             new TranslationInfo(LanguageCode.HE, "גאורגיה"),
+            new TranslationInfo(LanguageCode.HI, "जॉर्जिया"),
             new TranslationInfo(LanguageCode.HR, "Gruzija"),
             new TranslationInfo(LanguageCode.HU, "Grúzia"),
             new TranslationInfo(LanguageCode.HY, "Վրաստան"),

--- a/src/Nager.Country.Translation/CountryTranslations/GermanyCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/GermanyCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Saksa"),
             new TranslationInfo(LanguageCode.FR, "Allemagne"),
             new TranslationInfo(LanguageCode.HE, "גרמניה"),
+            new TranslationInfo(LanguageCode.HI, "जर्मनी"),
             new TranslationInfo(LanguageCode.HR, "Njemačka"),
             new TranslationInfo(LanguageCode.HU, "Németország"),
             new TranslationInfo(LanguageCode.HY, "Գերմանիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/GhanaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/GhanaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Ghana"),
             new TranslationInfo(LanguageCode.FR, "Ghana"),
             new TranslationInfo(LanguageCode.HE, "גאנה"),
+            new TranslationInfo(LanguageCode.HI, "घाना"),
             new TranslationInfo(LanguageCode.HR, "Gana"),
             new TranslationInfo(LanguageCode.HU, "Ghána"),
             new TranslationInfo(LanguageCode.HY, "Գանա"),

--- a/src/Nager.Country.Translation/CountryTranslations/GibraltarCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/GibraltarCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Gibraltar"),
             new TranslationInfo(LanguageCode.FR, "Gibraltar"),
             new TranslationInfo(LanguageCode.HE, "גיברלטר"),
+            new TranslationInfo(LanguageCode.HI, "जिब्राल्टर"),
             new TranslationInfo(LanguageCode.HR, "Gibraltar"),
             new TranslationInfo(LanguageCode.HU, "Gibraltár"),
             new TranslationInfo(LanguageCode.HY, "Ջիբրալթար"),

--- a/src/Nager.Country.Translation/CountryTranslations/GreeceCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/GreeceCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Kreikka"),
             new TranslationInfo(LanguageCode.FR, "Grèce"),
             new TranslationInfo(LanguageCode.HE, "יוון"),
+            new TranslationInfo(LanguageCode.HI, "यूनान"),
             new TranslationInfo(LanguageCode.HR, "Grčka"),
             new TranslationInfo(LanguageCode.HU, "Görögország"),
             new TranslationInfo(LanguageCode.HY, "Հունաստան"),

--- a/src/Nager.Country.Translation/CountryTranslations/GreenlandCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/GreenlandCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Grönlanti"),
             new TranslationInfo(LanguageCode.FR, "Groenland"),
             new TranslationInfo(LanguageCode.HE, "גרינלנד"),
+            new TranslationInfo(LanguageCode.HI, "ग्रीनलैंड"),
             new TranslationInfo(LanguageCode.HR, "Grenland"),
             new TranslationInfo(LanguageCode.HU, "Grönland"),
             new TranslationInfo(LanguageCode.HY, "Գրենլանդիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/GrenadaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/GrenadaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Grenada"),
             new TranslationInfo(LanguageCode.FR, "Grenada"),
             new TranslationInfo(LanguageCode.HE, "גרנדה"),
+            new TranslationInfo(LanguageCode.HI, "ग्रेनाडा"),
             new TranslationInfo(LanguageCode.HR, "Grenada"),
             new TranslationInfo(LanguageCode.HU, "Grenada"),
             new TranslationInfo(LanguageCode.HY, "Գրենադա"),

--- a/src/Nager.Country.Translation/CountryTranslations/GuadeloupeCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/GuadeloupeCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Guadeloupe"),
             new TranslationInfo(LanguageCode.FR, "Guadeloupe"),
             new TranslationInfo(LanguageCode.HE, "גוואדלופ"),
+            new TranslationInfo(LanguageCode.HI, "गुआदेलोप"),
             new TranslationInfo(LanguageCode.HR, "Guadalupe"),
             new TranslationInfo(LanguageCode.HU, "Guadeloupe"),
             new TranslationInfo(LanguageCode.HY, "Գվադելուպա"),

--- a/src/Nager.Country.Translation/CountryTranslations/GuamCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/GuamCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Guam"),
             new TranslationInfo(LanguageCode.FR, "Guam"),
             new TranslationInfo(LanguageCode.HE, "גואם"),
+            new TranslationInfo(LanguageCode.HI, "गुआम"),
             new TranslationInfo(LanguageCode.HR, "Guam"),
             new TranslationInfo(LanguageCode.HU, "Guam"),
             new TranslationInfo(LanguageCode.HY, "Գուամ"),

--- a/src/Nager.Country.Translation/CountryTranslations/GuatemalaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/GuatemalaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Guatemala"),
             new TranslationInfo(LanguageCode.FR, "Guatemala"),
             new TranslationInfo(LanguageCode.HE, "גואטמלה"),
+            new TranslationInfo(LanguageCode.HI, "ग्वाटेमाला"),
             new TranslationInfo(LanguageCode.HR, "Gvatemala"),
             new TranslationInfo(LanguageCode.HU, "Guatemala"),
             new TranslationInfo(LanguageCode.HY, "Գվատեմալա"),

--- a/src/Nager.Country.Translation/CountryTranslations/GuernseyCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/GuernseyCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Guernsey"),
             new TranslationInfo(LanguageCode.FR, "Guernesey"),
             new TranslationInfo(LanguageCode.HE, "גרנסי"),
+            new TranslationInfo(LanguageCode.HI, "गर्नसी"),
             new TranslationInfo(LanguageCode.HR, "Guernsey"),
             new TranslationInfo(LanguageCode.HU, "Guernsey"),
             new TranslationInfo(LanguageCode.HY, "Գերնսի"),

--- a/src/Nager.Country.Translation/CountryTranslations/GuineaBissauCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/GuineaBissauCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Guinea-Bissau"),
             new TranslationInfo(LanguageCode.FR, "Guinée-Bissau"),
             new TranslationInfo(LanguageCode.HE, "גינאה ביסאו"),
+            new TranslationInfo(LanguageCode.HI, "गिनी-बिसाऊ"),
             new TranslationInfo(LanguageCode.HR, "Gvineja Bisau"),
             new TranslationInfo(LanguageCode.HU, "Bissau-Guinea"),
             new TranslationInfo(LanguageCode.HY, "Գվինեա-Բիսսաու"),

--- a/src/Nager.Country.Translation/CountryTranslations/GuineaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/GuineaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Guinea"),
             new TranslationInfo(LanguageCode.FR, "Guinée"),
             new TranslationInfo(LanguageCode.HE, "גינאה"),
+            new TranslationInfo(LanguageCode.HI, "गिनी"),
             new TranslationInfo(LanguageCode.HR, "Gvineja"),
             new TranslationInfo(LanguageCode.HU, "Guinea"),
             new TranslationInfo(LanguageCode.HY, "Գվինեա"),

--- a/src/Nager.Country.Translation/CountryTranslations/GuyanaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/GuyanaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Guyana"),
             new TranslationInfo(LanguageCode.FR, "Guyana"),
             new TranslationInfo(LanguageCode.HE, "גיאנה"),
+            new TranslationInfo(LanguageCode.HI, "गुयाना"),
             new TranslationInfo(LanguageCode.HR, "Gvajana"),
             new TranslationInfo(LanguageCode.HU, "Guyana"),
             new TranslationInfo(LanguageCode.HY, "Գայանա"),

--- a/src/Nager.Country.Translation/CountryTranslations/HaitiCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/HaitiCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Haiti"),
             new TranslationInfo(LanguageCode.FR, "Haïti"),
             new TranslationInfo(LanguageCode.HE, "האיטי"),
+            new TranslationInfo(LanguageCode.HI, "हैती"),
             new TranslationInfo(LanguageCode.HR, "Haiti"),
             new TranslationInfo(LanguageCode.HU, "Haiti"),
             new TranslationInfo(LanguageCode.HY, "Հայիթի"),

--- a/src/Nager.Country.Translation/CountryTranslations/HeardIslandAndMcDonaldIslandsCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/HeardIslandAndMcDonaldIslandsCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Heard ja McDonaldinsaaret"),
             new TranslationInfo(LanguageCode.FR, "Îles Heard-et-MacDonald"),
             new TranslationInfo(LanguageCode.HE, "איי הרד ומקדונלד"),
+            new TranslationInfo(LanguageCode.HI, "हर्ड द्वीप और मैकडोनाल्ड द्वीपसमूह"),
             new TranslationInfo(LanguageCode.HR, "Otoci Heard i McDonald"),
             new TranslationInfo(LanguageCode.HU, "Heard-sziget és McDonald-szigetek"),
             new TranslationInfo(LanguageCode.HY, "Հերդ կղզի և ՄակԴոնալդի կղզիներ"),

--- a/src/Nager.Country.Translation/CountryTranslations/HondurasCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/HondurasCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Honduras"),
             new TranslationInfo(LanguageCode.FR, "Honduras"),
             new TranslationInfo(LanguageCode.HE, "הונדורס"),
+            new TranslationInfo(LanguageCode.HI, "होंडुरास"),
             new TranslationInfo(LanguageCode.HR, "Honduras"),
             new TranslationInfo(LanguageCode.HU, "Honduras"),
             new TranslationInfo(LanguageCode.HY, "Հոնդուրաս"),

--- a/src/Nager.Country.Translation/CountryTranslations/HongKongCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/HongKongCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Hongkong"),
             new TranslationInfo(LanguageCode.FR, "Hong Kong"),
             new TranslationInfo(LanguageCode.HE, "הונג קונג (מחוז מנהלי מיוחד של סין)"),
+            new TranslationInfo(LanguageCode.HI, "हांगकांग"),
             new TranslationInfo(LanguageCode.HR, "PUP Hong Kong Kina"),
             new TranslationInfo(LanguageCode.HU, "Hong Kong"),
             new TranslationInfo(LanguageCode.HY, "Հոնկոնգի ՀՎՇ"),

--- a/src/Nager.Country.Translation/CountryTranslations/HungaryCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/HungaryCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Unkari"),
             new TranslationInfo(LanguageCode.FR, "Hongrie"),
             new TranslationInfo(LanguageCode.HE, "הונגריה"),
+            new TranslationInfo(LanguageCode.HI, "हंगरी"),
             new TranslationInfo(LanguageCode.HR, "Mađarska"),
             new TranslationInfo(LanguageCode.HU, "Magyarország"),
             new TranslationInfo(LanguageCode.HY, "Հունգարիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/IcelandCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/IcelandCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Islanti"),
             new TranslationInfo(LanguageCode.FR, "Islande"),
             new TranslationInfo(LanguageCode.HE, "איסלנד"),
+            new TranslationInfo(LanguageCode.HI, "आइसलैंड"),
             new TranslationInfo(LanguageCode.HR, "Island"),
             new TranslationInfo(LanguageCode.HU, "Izland"),
             new TranslationInfo(LanguageCode.HY, "Իսլանդիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/IndiaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/IndiaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Intia"),
             new TranslationInfo(LanguageCode.FR, "Inde"),
             new TranslationInfo(LanguageCode.HE, "הודו"),
+            new TranslationInfo(LanguageCode.HI, "भारत"),
             new TranslationInfo(LanguageCode.HR, "Indija"),
             new TranslationInfo(LanguageCode.HU, "India"),
             new TranslationInfo(LanguageCode.HY, "Հնդկաստան"),

--- a/src/Nager.Country.Translation/CountryTranslations/IndonesiaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/IndonesiaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Indonesia"),
             new TranslationInfo(LanguageCode.FR, "Indonésie"),
             new TranslationInfo(LanguageCode.HE, "אינדונזיה"),
+            new TranslationInfo(LanguageCode.HI, "इंडोनेशिया"),
             new TranslationInfo(LanguageCode.HR, "Indonezija"),
             new TranslationInfo(LanguageCode.HU, "Indonézia"),
             new TranslationInfo(LanguageCode.HY, "Ինդոնեզիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/IranCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/IranCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Iran"),
             new TranslationInfo(LanguageCode.FR, "Iran"),
             new TranslationInfo(LanguageCode.HE, "איראן"),
+            new TranslationInfo(LanguageCode.HI, "ईरान"),
             new TranslationInfo(LanguageCode.HR, "Iran"),
             new TranslationInfo(LanguageCode.HU, "Irán"),
             new TranslationInfo(LanguageCode.HY, "Իրան"),

--- a/src/Nager.Country.Translation/CountryTranslations/IraqCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/IraqCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Irak"),
             new TranslationInfo(LanguageCode.FR, "Irak"),
             new TranslationInfo(LanguageCode.HE, "עיראק"),
+            new TranslationInfo(LanguageCode.HI, "इराक"),
             new TranslationInfo(LanguageCode.HR, "Irak"),
             new TranslationInfo(LanguageCode.HU, "Irak"),
             new TranslationInfo(LanguageCode.HY, "Իրաք"),

--- a/src/Nager.Country.Translation/CountryTranslations/IrelandCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/IrelandCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Irlanti"),
             new TranslationInfo(LanguageCode.FR, "Irlande"),
             new TranslationInfo(LanguageCode.HE, "אירלנד"),
+            new TranslationInfo(LanguageCode.HI, "आयरलैंड"),
             new TranslationInfo(LanguageCode.HR, "Irska"),
             new TranslationInfo(LanguageCode.HU, "Írország"),
             new TranslationInfo(LanguageCode.HY, "Իռլանդիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/IsleofManCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/IsleofManCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Mansaari"),
             new TranslationInfo(LanguageCode.FR, "Île de Man"),
             new TranslationInfo(LanguageCode.HE, "האי מאן"),
+            new TranslationInfo(LanguageCode.HI, "आइल ऑफ मैन"),
             new TranslationInfo(LanguageCode.HR, "Otok Man"),
             new TranslationInfo(LanguageCode.HU, "Man-sziget"),
             new TranslationInfo(LanguageCode.HY, "Մեն կղզի"),

--- a/src/Nager.Country.Translation/CountryTranslations/IsraelCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/IsraelCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Israel"),
             new TranslationInfo(LanguageCode.FR, "Israël"),
             new TranslationInfo(LanguageCode.HE, "ישראל"),
+            new TranslationInfo(LanguageCode.HI, "इज़राइल"),
             new TranslationInfo(LanguageCode.HR, "Izrael"),
             new TranslationInfo(LanguageCode.HU, "Izrael"),
             new TranslationInfo(LanguageCode.HY, "Իսրայել"),

--- a/src/Nager.Country.Translation/CountryTranslations/ItalyCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/ItalyCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Italia"),
             new TranslationInfo(LanguageCode.FR, "Italie"),
             new TranslationInfo(LanguageCode.HE, "איטליה"),
+            new TranslationInfo(LanguageCode.HI, "इटली"),
             new TranslationInfo(LanguageCode.HR, "Italija"),
             new TranslationInfo(LanguageCode.HU, "Olaszország"),
             new TranslationInfo(LanguageCode.HY, "Իտալիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/IvoryCoastCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/IvoryCoastCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Norsunluurannikko"),
             new TranslationInfo(LanguageCode.FR, "Côte-d'Ivoire"),
             new TranslationInfo(LanguageCode.HE, "חוף השנהב"),
+            new TranslationInfo(LanguageCode.HI, "आइवरी कोस्ट"),
             new TranslationInfo(LanguageCode.HR, "Obala Bjelokosti"),
             new TranslationInfo(LanguageCode.HU, "Elefántcsontpart"),
             new TranslationInfo(LanguageCode.HY, "Կոտ դ’Իվուար"),

--- a/src/Nager.Country.Translation/CountryTranslations/JamaicaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/JamaicaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Jamaika"),
             new TranslationInfo(LanguageCode.FR, "Jamaïque"),
             new TranslationInfo(LanguageCode.HE, "ג׳מייקה"),
+            new TranslationInfo(LanguageCode.HI, "जमैका"),
             new TranslationInfo(LanguageCode.HR, "Jamajka"),
             new TranslationInfo(LanguageCode.HU, "Jamaica"),
             new TranslationInfo(LanguageCode.HY, "Ճամայկա"),

--- a/src/Nager.Country.Translation/CountryTranslations/JapanCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/JapanCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Japani"),
             new TranslationInfo(LanguageCode.FR, "Japon"),
             new TranslationInfo(LanguageCode.HE, "יפן"),
+            new TranslationInfo(LanguageCode.HI, "जापान"),
             new TranslationInfo(LanguageCode.HR, "Japan"),
             new TranslationInfo(LanguageCode.HU, "Japán"),
             new TranslationInfo(LanguageCode.HY, "Ճապոնիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/JerseyCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/JerseyCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Jersey"),
             new TranslationInfo(LanguageCode.FR, "Jersey"),
             new TranslationInfo(LanguageCode.HE, "ג׳רסי"),
+            new TranslationInfo(LanguageCode.HI, "जर्सी"),
             new TranslationInfo(LanguageCode.HR, "Jersey"),
             new TranslationInfo(LanguageCode.HU, "Jersey"),
             new TranslationInfo(LanguageCode.HY, "Ջերսի"),

--- a/src/Nager.Country.Translation/CountryTranslations/JordanCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/JordanCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Jordania"),
             new TranslationInfo(LanguageCode.FR, "Jordanie"),
             new TranslationInfo(LanguageCode.HE, "ירדן"),
+            new TranslationInfo(LanguageCode.HI, "जॉर्डन"),
             new TranslationInfo(LanguageCode.HR, "Jordan"),
             new TranslationInfo(LanguageCode.HU, "Jordánia"),
             new TranslationInfo(LanguageCode.HY, "Հորդանան"),

--- a/src/Nager.Country.Translation/CountryTranslations/KazakhstanCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/KazakhstanCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Kazakstan"),
             new TranslationInfo(LanguageCode.FR, "Kazakhstan"),
             new TranslationInfo(LanguageCode.HE, "קזחסטן"),
+            new TranslationInfo(LanguageCode.HI, "कज़ाकस्तान"),
             new TranslationInfo(LanguageCode.HR, "Kazahstan"),
             new TranslationInfo(LanguageCode.HU, "Kazahsztán"),
             new TranslationInfo(LanguageCode.HY, "Ղազախստան"),

--- a/src/Nager.Country.Translation/CountryTranslations/KenyaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/KenyaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Kenia"),
             new TranslationInfo(LanguageCode.FR, "Kenya"),
             new TranslationInfo(LanguageCode.HE, "קניה"),
+            new TranslationInfo(LanguageCode.HI, "केन्या"),
             new TranslationInfo(LanguageCode.HR, "Kenija"),
             new TranslationInfo(LanguageCode.HU, "Kenya"),
             new TranslationInfo(LanguageCode.HY, "Քենիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/KiribatiCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/KiribatiCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Kiribati"),
             new TranslationInfo(LanguageCode.FR, "Kiribati"),
             new TranslationInfo(LanguageCode.HE, "קיריבאטי"),
+            new TranslationInfo(LanguageCode.HI, "किरिबाती"),
             new TranslationInfo(LanguageCode.HR, "Kiribati"),
             new TranslationInfo(LanguageCode.HU, "Kiribati"),
             new TranslationInfo(LanguageCode.HY, "Կիրիբատի"),

--- a/src/Nager.Country.Translation/CountryTranslations/KosovoCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/KosovoCountryTranslation.cs
@@ -15,6 +15,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.IT, "Kosovo"),
             new TranslationInfo(LanguageCode.NL, "Kosovo"),
             new TranslationInfo(LanguageCode.PT, "Kosovo"),
+            new TranslationInfo(LanguageCode.HI, "कोसोवो"),
         };
     }
 }

--- a/src/Nager.Country.Translation/CountryTranslations/KosovoCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/KosovoCountryTranslation.cs
@@ -12,10 +12,10 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.EN, "Kosovo"),
             new TranslationInfo(LanguageCode.ES, "Kosovo"),
             new TranslationInfo(LanguageCode.FR, "Kosovo"),
+            new TranslationInfo(LanguageCode.HI, "कोसोवो"),
             new TranslationInfo(LanguageCode.IT, "Kosovo"),
             new TranslationInfo(LanguageCode.NL, "Kosovo"),
             new TranslationInfo(LanguageCode.PT, "Kosovo"),
-            new TranslationInfo(LanguageCode.HI, "कोसोवो"),
         };
     }
 }

--- a/src/Nager.Country.Translation/CountryTranslations/KuwaitCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/KuwaitCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Kuwait"),
             new TranslationInfo(LanguageCode.FR, "Koweit"),
             new TranslationInfo(LanguageCode.HE, "כווית"),
+            new TranslationInfo(LanguageCode.HI, "कुवैत"),
             new TranslationInfo(LanguageCode.HR, "Kuvajt"),
             new TranslationInfo(LanguageCode.HU, "Kuvait"),
             new TranslationInfo(LanguageCode.HY, "Քուվեյթ"),

--- a/src/Nager.Country.Translation/CountryTranslations/KyrgyzstanCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/KyrgyzstanCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Kirgisia"),
             new TranslationInfo(LanguageCode.FR, "Kirghistan"),
             new TranslationInfo(LanguageCode.HE, "קירגיזסטן"),
+            new TranslationInfo(LanguageCode.HI, "किर्गिज़स्तान"),
             new TranslationInfo(LanguageCode.HR, "Kirgistan"),
             new TranslationInfo(LanguageCode.HU, "Kirgizisztán"),
             new TranslationInfo(LanguageCode.HY, "Ղրղզստան"),

--- a/src/Nager.Country.Translation/CountryTranslations/LaosCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/LaosCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Laos"),
             new TranslationInfo(LanguageCode.FR, "Laos"),
             new TranslationInfo(LanguageCode.HE, "לאוס"),
+            new TranslationInfo(LanguageCode.HI, "लाओस"),
             new TranslationInfo(LanguageCode.HR, "Laos"),
             new TranslationInfo(LanguageCode.HU, "Laosz"),
             new TranslationInfo(LanguageCode.HY, "Լաոս"),

--- a/src/Nager.Country.Translation/CountryTranslations/LatviaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/LatviaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Latvia"),
             new TranslationInfo(LanguageCode.FR, "Lettonie"),
             new TranslationInfo(LanguageCode.HE, "לטביה"),
+            new TranslationInfo(LanguageCode.HI, "लातविया"),
             new TranslationInfo(LanguageCode.HR, "Latvija"),
             new TranslationInfo(LanguageCode.HU, "Lettország"),
             new TranslationInfo(LanguageCode.HY, "Լատվիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/LebanonCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/LebanonCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Libanon"),
             new TranslationInfo(LanguageCode.FR, "Liban"),
             new TranslationInfo(LanguageCode.HE, "לבנון"),
+            new TranslationInfo(LanguageCode.HI, "लेबनान"),
             new TranslationInfo(LanguageCode.HR, "Libanon"),
             new TranslationInfo(LanguageCode.HU, "Libanon"),
             new TranslationInfo(LanguageCode.HY, "Լիբանան"),

--- a/src/Nager.Country.Translation/CountryTranslations/LesothoCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/LesothoCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Lesotho"),
             new TranslationInfo(LanguageCode.FR, "Lesotho"),
             new TranslationInfo(LanguageCode.HE, "לסוטו"),
+            new TranslationInfo(LanguageCode.HI, "लेसोथो"),
             new TranslationInfo(LanguageCode.HR, "Lesoto"),
             new TranslationInfo(LanguageCode.HU, "Lesotho"),
             new TranslationInfo(LanguageCode.HY, "Լեսոտո"),

--- a/src/Nager.Country.Translation/CountryTranslations/LiberiaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/LiberiaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Liberia"),
             new TranslationInfo(LanguageCode.FR, "Libéria"),
             new TranslationInfo(LanguageCode.HE, "ליבריה"),
+            new TranslationInfo(LanguageCode.HI, "लाइबेरिया"),
             new TranslationInfo(LanguageCode.HR, "Liberija"),
             new TranslationInfo(LanguageCode.HU, "Libéria"),
             new TranslationInfo(LanguageCode.HY, "Լիբերիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/LibyaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/LibyaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Libya"),
             new TranslationInfo(LanguageCode.FR, "Libye"),
             new TranslationInfo(LanguageCode.HE, "לוב"),
+            new TranslationInfo(LanguageCode.HI, "लीबिया"),
             new TranslationInfo(LanguageCode.HR, "Libija"),
             new TranslationInfo(LanguageCode.HU, "Líbia"),
             new TranslationInfo(LanguageCode.HY, "Լիբիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/LiechtensteinCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/LiechtensteinCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Liechtenstein"),
             new TranslationInfo(LanguageCode.FR, "Liechtenstein"),
             new TranslationInfo(LanguageCode.HE, "ליכטנשטיין"),
+            new TranslationInfo(LanguageCode.HI, "लिकटेंस्टाइन"),
             new TranslationInfo(LanguageCode.HR, "Lihtenštajn"),
             new TranslationInfo(LanguageCode.HU, "Liechtenstein"),
             new TranslationInfo(LanguageCode.HY, "Լիխտենշտեյն"),

--- a/src/Nager.Country.Translation/CountryTranslations/LithuaniaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/LithuaniaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Liettua"),
             new TranslationInfo(LanguageCode.FR, "Lituanie"),
             new TranslationInfo(LanguageCode.HE, "ליטא"),
+            new TranslationInfo(LanguageCode.HI, "लिथुआनिया"),
             new TranslationInfo(LanguageCode.HR, "Litva"),
             new TranslationInfo(LanguageCode.HU, "Litvánia"),
             new TranslationInfo(LanguageCode.HY, "Լիտվա"),

--- a/src/Nager.Country.Translation/CountryTranslations/LuxembourgCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/LuxembourgCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Luxemburg"),
             new TranslationInfo(LanguageCode.FR, "Luxembourg, Grand-Duché"),
             new TranslationInfo(LanguageCode.HE, "לוקסמבורג"),
+            new TranslationInfo(LanguageCode.HI, "लक्ज़मबर्ग"),
             new TranslationInfo(LanguageCode.HR, "Luksemburg"),
             new TranslationInfo(LanguageCode.HU, "Luxemburg"),
             new TranslationInfo(LanguageCode.HY, "Լյուքսեմբուրգ"),

--- a/src/Nager.Country.Translation/CountryTranslations/MacauCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/MacauCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Macao"),
             new TranslationInfo(LanguageCode.FR, "Macao"),
             new TranslationInfo(LanguageCode.HE, "מקאו (מחוז מנהלי מיוחד של סין)"),
+            new TranslationInfo(LanguageCode.HI, "मकाऊ"),
             new TranslationInfo(LanguageCode.HR, "PUP Makao Kina"),
             new TranslationInfo(LanguageCode.HU, "Makao"),
             new TranslationInfo(LanguageCode.HY, "Չինաստանի Մակաո ՀՎՇ"),

--- a/src/Nager.Country.Translation/CountryTranslations/MadagascarCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/MadagascarCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Madagaskar"),
             new TranslationInfo(LanguageCode.FR, "Madagascar"),
             new TranslationInfo(LanguageCode.HE, "מדגסקר"),
+            new TranslationInfo(LanguageCode.HI, "मेडागास्कर"),
             new TranslationInfo(LanguageCode.HR, "Madagaskar"),
             new TranslationInfo(LanguageCode.HU, "Madagaszkár"),
             new TranslationInfo(LanguageCode.HY, "Մադագասկար"),

--- a/src/Nager.Country.Translation/CountryTranslations/MalawiCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/MalawiCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Malawi"),
             new TranslationInfo(LanguageCode.FR, "Malawi"),
             new TranslationInfo(LanguageCode.HE, "מלאווי"),
+            new TranslationInfo(LanguageCode.HI, "मलावी"),
             new TranslationInfo(LanguageCode.HR, "Malavi"),
             new TranslationInfo(LanguageCode.HU, "Malawi"),
             new TranslationInfo(LanguageCode.HY, "Մալավի"),

--- a/src/Nager.Country.Translation/CountryTranslations/MalaysiaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/MalaysiaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Malesia"),
             new TranslationInfo(LanguageCode.FR, "Malaisie"),
             new TranslationInfo(LanguageCode.HE, "מלזיה"),
+            new TranslationInfo(LanguageCode.HI, "मलेशिया"),
             new TranslationInfo(LanguageCode.HR, "Malezija"),
             new TranslationInfo(LanguageCode.HU, "Malajzia"),
             new TranslationInfo(LanguageCode.HY, "Մալայզիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/MaldivesCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/MaldivesCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Malediivit"),
             new TranslationInfo(LanguageCode.FR, "Maldives"),
             new TranslationInfo(LanguageCode.HE, "האיים המלדיביים"),
+            new TranslationInfo(LanguageCode.HI, "मालदीव"),
             new TranslationInfo(LanguageCode.HR, "Maldivi"),
             new TranslationInfo(LanguageCode.HU, "Maldív-szigetek"),
             new TranslationInfo(LanguageCode.HY, "Մալդիվներ"),

--- a/src/Nager.Country.Translation/CountryTranslations/MaliCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/MaliCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Mali"),
             new TranslationInfo(LanguageCode.FR, "Mali"),
             new TranslationInfo(LanguageCode.HE, "מאלי"),
+            new TranslationInfo(LanguageCode.HI, "माली"),
             new TranslationInfo(LanguageCode.HR, "Mali"),
             new TranslationInfo(LanguageCode.HU, "Mali"),
             new TranslationInfo(LanguageCode.HY, "Մալի"),

--- a/src/Nager.Country.Translation/CountryTranslations/MaltaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/MaltaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Malta"),
             new TranslationInfo(LanguageCode.FR, "Malte"),
             new TranslationInfo(LanguageCode.HE, "מלטה"),
+            new TranslationInfo(LanguageCode.HI, "माल्टा"),
             new TranslationInfo(LanguageCode.HR, "Malta"),
             new TranslationInfo(LanguageCode.HU, "Málta"),
             new TranslationInfo(LanguageCode.HY, "Մալթա"),

--- a/src/Nager.Country.Translation/CountryTranslations/MarshallIslandsCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/MarshallIslandsCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Marshallinsaaret"),
             new TranslationInfo(LanguageCode.FR, "Îles Marshall"),
             new TranslationInfo(LanguageCode.HE, "איי מרשל"),
+            new TranslationInfo(LanguageCode.HI, "मार्शल द्वीपसमूह"),
             new TranslationInfo(LanguageCode.HR, "Maršalovi Otoci"),
             new TranslationInfo(LanguageCode.HU, "Marshall-szigetek"),
             new TranslationInfo(LanguageCode.HY, "Մարշալյան կղզիներ"),

--- a/src/Nager.Country.Translation/CountryTranslations/MartiniqueCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/MartiniqueCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Martinique"),
             new TranslationInfo(LanguageCode.FR, "Martinique"),
             new TranslationInfo(LanguageCode.HE, "מרטיניק"),
+            new TranslationInfo(LanguageCode.HI, "मार्टिनिक"),
             new TranslationInfo(LanguageCode.HR, "Martinique"),
             new TranslationInfo(LanguageCode.HU, "Martinique"),
             new TranslationInfo(LanguageCode.HY, "Մարտինիկա"),

--- a/src/Nager.Country.Translation/CountryTranslations/MauritaniaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/MauritaniaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Mauritania"),
             new TranslationInfo(LanguageCode.FR, "Mauritanie"),
             new TranslationInfo(LanguageCode.HE, "מאוריטניה"),
+            new TranslationInfo(LanguageCode.HI, "मॉरिटानिया"),
             new TranslationInfo(LanguageCode.HR, "Mauretanija"),
             new TranslationInfo(LanguageCode.HU, "Mauritánia"),
             new TranslationInfo(LanguageCode.HY, "Մավրիտանիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/MauritiusCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/MauritiusCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Mauritius"),
             new TranslationInfo(LanguageCode.FR, "Maurice"),
             new TranslationInfo(LanguageCode.HE, "מאוריציוס"),
+            new TranslationInfo(LanguageCode.HI, "मॉरीशस"),
             new TranslationInfo(LanguageCode.HR, "Mauricijus"),
             new TranslationInfo(LanguageCode.HU, "Mauritius"),
             new TranslationInfo(LanguageCode.HY, "Մավրիկիոս"),

--- a/src/Nager.Country.Translation/CountryTranslations/MayotteCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/MayotteCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Mayotte"),
             new TranslationInfo(LanguageCode.FR, "Mayotte"),
             new TranslationInfo(LanguageCode.HE, "מאיוט"),
+            new TranslationInfo(LanguageCode.HI, "मायोट"),
             new TranslationInfo(LanguageCode.HR, "Mayotte"),
             new TranslationInfo(LanguageCode.HU, "Mayotte"),
             new TranslationInfo(LanguageCode.HY, "Մայոտ"),

--- a/src/Nager.Country.Translation/CountryTranslations/MexicoCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/MexicoCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Meksiko"),
             new TranslationInfo(LanguageCode.FR, "Mexique"),
             new TranslationInfo(LanguageCode.HE, "מקסיקו"),
+            new TranslationInfo(LanguageCode.HI, "मेक्सिको"),
             new TranslationInfo(LanguageCode.HR, "Meksiko"),
             new TranslationInfo(LanguageCode.HU, "Mexikó"),
             new TranslationInfo(LanguageCode.HY, "Մեքսիկա"),

--- a/src/Nager.Country.Translation/CountryTranslations/MicronesiaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/MicronesiaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Mikronesian liittovaltio"),
             new TranslationInfo(LanguageCode.FR, "Micronésie"),
             new TranslationInfo(LanguageCode.HE, "מיקרונזיה"),
+            new TranslationInfo(LanguageCode.HI, "माइक्रोनेशिया"),
             new TranslationInfo(LanguageCode.HR, "Mikronezija"),
             new TranslationInfo(LanguageCode.HU, "Mikronéziai Szövetségi Államok"),
             new TranslationInfo(LanguageCode.HY, "Միկրոնեզիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/MoldovaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/MoldovaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Moldova"),
             new TranslationInfo(LanguageCode.FR, "Moldavie"),
             new TranslationInfo(LanguageCode.HE, "מולדובה"),
+            new TranslationInfo(LanguageCode.HI, "मोल्दोवा"),
             new TranslationInfo(LanguageCode.HR, "Moldavija"),
             new TranslationInfo(LanguageCode.HU, "Moldova"),
             new TranslationInfo(LanguageCode.HY, "Մոլդովա"),

--- a/src/Nager.Country.Translation/CountryTranslations/MonacoCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/MonacoCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Monaco"),
             new TranslationInfo(LanguageCode.FR, "Monaco"),
             new TranslationInfo(LanguageCode.HE, "מונקו"),
+            new TranslationInfo(LanguageCode.HI, "मोनाको"),
             new TranslationInfo(LanguageCode.HR, "Monako"),
             new TranslationInfo(LanguageCode.HU, "Monaco"),
             new TranslationInfo(LanguageCode.HY, "Մոնակո"),

--- a/src/Nager.Country.Translation/CountryTranslations/MongoliaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/MongoliaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Mongolia"),
             new TranslationInfo(LanguageCode.FR, "Mongolie"),
             new TranslationInfo(LanguageCode.HE, "מונגוליה"),
+            new TranslationInfo(LanguageCode.HI, "मंगोलिया"),
             new TranslationInfo(LanguageCode.HR, "Mongolija"),
             new TranslationInfo(LanguageCode.HU, "Mongólia"),
             new TranslationInfo(LanguageCode.HY, "Մոնղոլիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/MontenegroCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/MontenegroCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Montenegro"),
             new TranslationInfo(LanguageCode.FR, "Monténégro"),
             new TranslationInfo(LanguageCode.HE, "מונטנגרו"),
+            new TranslationInfo(LanguageCode.HI, "मोंटेनेग्रो"),
             new TranslationInfo(LanguageCode.HR, "Crna Gora"),
             new TranslationInfo(LanguageCode.HU, "Montenegró"),
             new TranslationInfo(LanguageCode.HY, "Չեռնոգորիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/MontserratCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/MontserratCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Montserrat"),
             new TranslationInfo(LanguageCode.FR, "Montserrat"),
             new TranslationInfo(LanguageCode.HE, "מונסראט"),
+            new TranslationInfo(LanguageCode.HI, "मोंटसेरात"),
             new TranslationInfo(LanguageCode.HR, "Montserrat"),
             new TranslationInfo(LanguageCode.HU, "Montserrat"),
             new TranslationInfo(LanguageCode.HY, "Մոնսեռատ"),

--- a/src/Nager.Country.Translation/CountryTranslations/MoroccoCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/MoroccoCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Marokko"),
             new TranslationInfo(LanguageCode.FR, "Maroc"),
             new TranslationInfo(LanguageCode.HE, "מרוקו"),
+            new TranslationInfo(LanguageCode.HI, "मोरक्को"),
             new TranslationInfo(LanguageCode.HR, "Maroko"),
             new TranslationInfo(LanguageCode.HU, "Marokkó"),
             new TranslationInfo(LanguageCode.HY, "Մարոկկո"),

--- a/src/Nager.Country.Translation/CountryTranslations/MozambiqueCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/MozambiqueCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Mosambik"),
             new TranslationInfo(LanguageCode.FR, "Mozambique"),
             new TranslationInfo(LanguageCode.HE, "מוזמביק"),
+            new TranslationInfo(LanguageCode.HI, "मोज़ाम्बिक"),
             new TranslationInfo(LanguageCode.HR, "Mozambik"),
             new TranslationInfo(LanguageCode.HU, "Mozambik"),
             new TranslationInfo(LanguageCode.HY, "Մոզամբիկ"),

--- a/src/Nager.Country.Translation/CountryTranslations/MyanmarCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/MyanmarCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Myanmar"),
             new TranslationInfo(LanguageCode.FR, "Myanmar"),
             new TranslationInfo(LanguageCode.HE, "מיאנמר (בורמה)"),
+            new TranslationInfo(LanguageCode.HI, "म्यांमार"),
             new TranslationInfo(LanguageCode.HR, "Mjanmar (Burma)"),
             new TranslationInfo(LanguageCode.HU, "Mianmar"),
             new TranslationInfo(LanguageCode.HY, "Մյանմա (Բիրմա)"),

--- a/src/Nager.Country.Translation/CountryTranslations/NamibiaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/NamibiaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Namibia"),
             new TranslationInfo(LanguageCode.FR, "Namibie"),
             new TranslationInfo(LanguageCode.HE, "נמיביה"),
+            new TranslationInfo(LanguageCode.HI, "नामीबिया"),
             new TranslationInfo(LanguageCode.HR, "Namibija"),
             new TranslationInfo(LanguageCode.HU, "Namíbia"),
             new TranslationInfo(LanguageCode.HY, "Նամիբիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/NauruCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/NauruCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Nauru"),
             new TranslationInfo(LanguageCode.FR, "Nauru"),
             new TranslationInfo(LanguageCode.HE, "נאורו"),
+            new TranslationInfo(LanguageCode.HI, "नाउरू"),
             new TranslationInfo(LanguageCode.HR, "Nauru"),
             new TranslationInfo(LanguageCode.HU, "Nauru"),
             new TranslationInfo(LanguageCode.HY, "Նաուրու"),

--- a/src/Nager.Country.Translation/CountryTranslations/NepalCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/NepalCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Nepal"),
             new TranslationInfo(LanguageCode.FR, "Népal"),
             new TranslationInfo(LanguageCode.HE, "נפאל"),
+            new TranslationInfo(LanguageCode.HI, "नेपाल"),
             new TranslationInfo(LanguageCode.HR, "Nepal"),
             new TranslationInfo(LanguageCode.HU, "Nepál"),
             new TranslationInfo(LanguageCode.HY, "Նեպալ"),

--- a/src/Nager.Country.Translation/CountryTranslations/NetherlandsCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/NetherlandsCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Alankomaat"),
             new TranslationInfo(LanguageCode.FR, "Pays-Bas"),
             new TranslationInfo(LanguageCode.HE, "הולנד"),
+            new TranslationInfo(LanguageCode.HI, "नीदरलैंड"),
             new TranslationInfo(LanguageCode.HR, "Nizozemska"),
             new TranslationInfo(LanguageCode.HU, "Hollandia"),
             new TranslationInfo(LanguageCode.HY, "Նիդեռլանդներ"),

--- a/src/Nager.Country.Translation/CountryTranslations/NewCaledoniaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/NewCaledoniaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Uusi-Kaledonia"),
             new TranslationInfo(LanguageCode.FR, "Nouvelle-Calédonie"),
             new TranslationInfo(LanguageCode.HE, "קלדוניה החדשה"),
+            new TranslationInfo(LanguageCode.HI, "न्यू कैलेडोनिया"),
             new TranslationInfo(LanguageCode.HR, "Nova Kaledonija"),
             new TranslationInfo(LanguageCode.HU, "Új-Kaledónia"),
             new TranslationInfo(LanguageCode.HY, "Նոր Կալեդոնիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/NewZealandCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/NewZealandCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Uusi-Seelanti"),
             new TranslationInfo(LanguageCode.FR, "Nouvelle-Zélande"),
             new TranslationInfo(LanguageCode.HE, "ניו זילנד"),
+            new TranslationInfo(LanguageCode.HI, "न्यूज़ीलैंड"),
             new TranslationInfo(LanguageCode.HR, "Novi Zeland"),
             new TranslationInfo(LanguageCode.HU, "Új-Zéland"),
             new TranslationInfo(LanguageCode.HY, "Նոր Զելանդիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/NicaraguaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/NicaraguaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Nicaragua"),
             new TranslationInfo(LanguageCode.FR, "Nicaragua"),
             new TranslationInfo(LanguageCode.HE, "ניקרגואה"),
+            new TranslationInfo(LanguageCode.HI, "निकारागुआ"),
             new TranslationInfo(LanguageCode.HR, "Nikaragva"),
             new TranslationInfo(LanguageCode.HU, "Nicaragua"),
             new TranslationInfo(LanguageCode.HY, "Նիկարագուա"),

--- a/src/Nager.Country.Translation/CountryTranslations/NigerCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/NigerCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Niger"),
             new TranslationInfo(LanguageCode.FR, "Niger"),
             new TranslationInfo(LanguageCode.HE, "ניז׳ר"),
+            new TranslationInfo(LanguageCode.HI, "नाइजर"),
             new TranslationInfo(LanguageCode.HR, "Niger"),
             new TranslationInfo(LanguageCode.HU, "Niger"),
             new TranslationInfo(LanguageCode.HY, "Նիգեր"),

--- a/src/Nager.Country.Translation/CountryTranslations/NigeriaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/NigeriaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Nigeria"),
             new TranslationInfo(LanguageCode.FR, "Nigéria"),
             new TranslationInfo(LanguageCode.HE, "ניגריה"),
+            new TranslationInfo(LanguageCode.HI, "नाइजीरिया"),
             new TranslationInfo(LanguageCode.HR, "Nigerija"),
             new TranslationInfo(LanguageCode.HU, "Nigéria"),
             new TranslationInfo(LanguageCode.HY, "Նիգերիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/NiueCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/NiueCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Niue"),
             new TranslationInfo(LanguageCode.FR, "Niué"),
             new TranslationInfo(LanguageCode.HE, "ניווה"),
+            new TranslationInfo(LanguageCode.HI, "नीयू"),
             new TranslationInfo(LanguageCode.HR, "Niue"),
             new TranslationInfo(LanguageCode.HU, "Niue"),
             new TranslationInfo(LanguageCode.HY, "Նիուե"),

--- a/src/Nager.Country.Translation/CountryTranslations/NorfolkIslandCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/NorfolkIslandCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Norfolkinsaari"),
             new TranslationInfo(LanguageCode.FR, "Île Norfolk"),
             new TranslationInfo(LanguageCode.HE, "איי נורפוק"),
+            new TranslationInfo(LanguageCode.HI, "नॉरफ़ॉक द्वीप"),
             new TranslationInfo(LanguageCode.HR, "Otok Norfolk"),
             new TranslationInfo(LanguageCode.HU, "Norfolk-sziget"),
             new TranslationInfo(LanguageCode.HY, "Նորֆոլկ կղզի"),

--- a/src/Nager.Country.Translation/CountryTranslations/NorthKoreaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/NorthKoreaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Korean demokraattinen kansantasavalta"),
             new TranslationInfo(LanguageCode.FR, "Corée du Nord, République populaire démocratique"),
             new TranslationInfo(LanguageCode.HE, "קוריאה הצפונית"),
+            new TranslationInfo(LanguageCode.HI, "उत्तर कोरिया"),
             new TranslationInfo(LanguageCode.HR, "Sjeverna Koreja"),
             new TranslationInfo(LanguageCode.HU, "Észak-Korea"),
             new TranslationInfo(LanguageCode.HY, "Հյուսիսային Կորեա"),

--- a/src/Nager.Country.Translation/CountryTranslations/NorthMacedoniaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/NorthMacedoniaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Pohjois-Makedonia"),
             new TranslationInfo(LanguageCode.FR, "Macédoine du Nord"),
             new TranslationInfo(LanguageCode.HE, "צפון מקדוניה"),
+            new TranslationInfo(LanguageCode.HI, "उत्तर मैसेडोनिया"),
             new TranslationInfo(LanguageCode.HR, "Sjeverna Makedonija"),
             new TranslationInfo(LanguageCode.HU, "Észak-Macedónia"),
             new TranslationInfo(LanguageCode.HY, "Հյուսիսային Մակեդոնիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/NorthernMarianaIslandsCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/NorthernMarianaIslandsCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Pohjois-Mariaanit"),
             new TranslationInfo(LanguageCode.FR, "Mariannes du Nord"),
             new TranslationInfo(LanguageCode.HE, "איי מריאנה הצפוניים"),
+            new TranslationInfo(LanguageCode.HI, "उत्तरी मरियाना द्वीपसमूह"),
             new TranslationInfo(LanguageCode.HR, "Sjevernomarijanski otoci"),
             new TranslationInfo(LanguageCode.HU, "Északi-Mariana-szigetek"),
             new TranslationInfo(LanguageCode.HY, "Հյուսիսային Մարիանյան կղզիներ"),

--- a/src/Nager.Country.Translation/CountryTranslations/NorwayCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/NorwayCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Norja"),
             new TranslationInfo(LanguageCode.FR, "Norvège"),
             new TranslationInfo(LanguageCode.HE, "נורווגיה"),
+            new TranslationInfo(LanguageCode.HI, "नॉर्वे"),
             new TranslationInfo(LanguageCode.HR, "Norveška"),
             new TranslationInfo(LanguageCode.HU, "Norvégia"),
             new TranslationInfo(LanguageCode.HY, "Նորվեգիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/OmanCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/OmanCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Oman"),
             new TranslationInfo(LanguageCode.FR, "Oman"),
             new TranslationInfo(LanguageCode.HE, "עומאן"),
+            new TranslationInfo(LanguageCode.HI, "ओमान"),
             new TranslationInfo(LanguageCode.HR, "Oman"),
             new TranslationInfo(LanguageCode.HU, "Omán"),
             new TranslationInfo(LanguageCode.HY, "Օման"),

--- a/src/Nager.Country.Translation/CountryTranslations/PakistanCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/PakistanCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Pakistan"),
             new TranslationInfo(LanguageCode.FR, "Pakistan"),
             new TranslationInfo(LanguageCode.HE, "פקיסטן"),
+            new TranslationInfo(LanguageCode.HI, "पाकिस्तान"),
             new TranslationInfo(LanguageCode.HR, "Pakistan"),
             new TranslationInfo(LanguageCode.HU, "Pakisztán"),
             new TranslationInfo(LanguageCode.HY, "Պակիստան"),

--- a/src/Nager.Country.Translation/CountryTranslations/PalauCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/PalauCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Palau"),
             new TranslationInfo(LanguageCode.FR, "Palau"),
             new TranslationInfo(LanguageCode.HE, "פלאו"),
+            new TranslationInfo(LanguageCode.HI, "पलाऊ"),
             new TranslationInfo(LanguageCode.HR, "Palau"),
             new TranslationInfo(LanguageCode.HU, "Palau"),
             new TranslationInfo(LanguageCode.HY, "Պալաու"),

--- a/src/Nager.Country.Translation/CountryTranslations/PalestineCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/PalestineCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Palestiina"),
             new TranslationInfo(LanguageCode.FR, "Palestine"),
             new TranslationInfo(LanguageCode.HE, "השטחים הפלסטיניים"),
+            new TranslationInfo(LanguageCode.HI, "फ़िलिस्तीन"),
             new TranslationInfo(LanguageCode.HR, "Palestinsko Područje"),
             new TranslationInfo(LanguageCode.HU, "Palesztina"),
             new TranslationInfo(LanguageCode.HY, "Պաղեստինյան տարածքներ"),

--- a/src/Nager.Country.Translation/CountryTranslations/PanamaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/PanamaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Panama"),
             new TranslationInfo(LanguageCode.FR, "Panama"),
             new TranslationInfo(LanguageCode.HE, "פנמה"),
+            new TranslationInfo(LanguageCode.HI, "पनामा"),
             new TranslationInfo(LanguageCode.HR, "Panama"),
             new TranslationInfo(LanguageCode.HU, "Panama"),
             new TranslationInfo(LanguageCode.HY, "Պանամա"),

--- a/src/Nager.Country.Translation/CountryTranslations/PapuaNewGuineaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/PapuaNewGuineaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Papua-Uusi-Guinea"),
             new TranslationInfo(LanguageCode.FR, "Papouasie-Nouvelle-Guinée"),
             new TranslationInfo(LanguageCode.HE, "פפואה גינאה החדשה"),
+            new TranslationInfo(LanguageCode.HI, "पापुआ न्यू गिनी"),
             new TranslationInfo(LanguageCode.HR, "Papua Nova Gvineja"),
             new TranslationInfo(LanguageCode.HU, "Pápua Új-Guinea"),
             new TranslationInfo(LanguageCode.HY, "Պապուա Նոր Գվինեա"),

--- a/src/Nager.Country.Translation/CountryTranslations/ParaguayCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/ParaguayCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Paraguay"),
             new TranslationInfo(LanguageCode.FR, "Paraguay"),
             new TranslationInfo(LanguageCode.HE, "פרגוואי"),
+            new TranslationInfo(LanguageCode.HI, "पराग्वे"),
             new TranslationInfo(LanguageCode.HR, "Paragvaj"),
             new TranslationInfo(LanguageCode.HU, "Paraguay"),
             new TranslationInfo(LanguageCode.HY, "Պարագվայ"),

--- a/src/Nager.Country.Translation/CountryTranslations/PeruCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/PeruCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Peru"),
             new TranslationInfo(LanguageCode.FR, "Pérou"),
             new TranslationInfo(LanguageCode.HE, "פרו"),
+            new TranslationInfo(LanguageCode.HI, "पेरू"),
             new TranslationInfo(LanguageCode.HR, "Peru"),
             new TranslationInfo(LanguageCode.HU, "Peru"),
             new TranslationInfo(LanguageCode.HY, "Պերու"),

--- a/src/Nager.Country.Translation/CountryTranslations/PhilippinesCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/PhilippinesCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Filippiinit"),
             new TranslationInfo(LanguageCode.FR, "Philippines"),
             new TranslationInfo(LanguageCode.HE, "הפיליפינים"),
+            new TranslationInfo(LanguageCode.HI, "फ़िलीपींस"),
             new TranslationInfo(LanguageCode.HR, "Filipini"),
             new TranslationInfo(LanguageCode.HU, "Fülöp-szigetek"),
             new TranslationInfo(LanguageCode.HY, "Ֆիլիպիններ"),

--- a/src/Nager.Country.Translation/CountryTranslations/PitcairnIslandsCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/PitcairnIslandsCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Pitcairn"),
             new TranslationInfo(LanguageCode.FR, "Pitcairn"),
             new TranslationInfo(LanguageCode.HE, "איי פיטקרן"),
+            new TranslationInfo(LanguageCode.HI, "पिटकेर्न द्वीपसमूह"),
             new TranslationInfo(LanguageCode.HR, "Otoci Pitcairn"),
             new TranslationInfo(LanguageCode.HU, "Pitcairn-szigetek"),
             new TranslationInfo(LanguageCode.HY, "Պիտկեռն կղզիներ"),

--- a/src/Nager.Country.Translation/CountryTranslations/PolandCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/PolandCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Puola"),
             new TranslationInfo(LanguageCode.FR, "Pologne"),
             new TranslationInfo(LanguageCode.HE, "פולין"),
+            new TranslationInfo(LanguageCode.HI, "पोलैंड"),
             new TranslationInfo(LanguageCode.HR, "Poljska"),
             new TranslationInfo(LanguageCode.HU, "Lengyelország"),
             new TranslationInfo(LanguageCode.HY, "Լեհաստան"),

--- a/src/Nager.Country.Translation/CountryTranslations/PortugalCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/PortugalCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Portugali"),
             new TranslationInfo(LanguageCode.FR, "Portugal"),
             new TranslationInfo(LanguageCode.HE, "פורטוגל"),
+            new TranslationInfo(LanguageCode.HI, "पुर्तगाल"),
             new TranslationInfo(LanguageCode.HR, "Portugal"),
             new TranslationInfo(LanguageCode.HU, "Portugália"),
             new TranslationInfo(LanguageCode.HY, "Պորտուգալիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/PuertoRicoCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/PuertoRicoCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Puerto Rico"),
             new TranslationInfo(LanguageCode.FR, "Porto Rico"),
             new TranslationInfo(LanguageCode.HE, "פוארטו ריקו"),
+            new TranslationInfo(LanguageCode.HI, "प्यूर्टो रिको"),
             new TranslationInfo(LanguageCode.HR, "Portoriko"),
             new TranslationInfo(LanguageCode.HU, "Puerto Rico"),
             new TranslationInfo(LanguageCode.HY, "Պուերտո Ռիկո"),

--- a/src/Nager.Country.Translation/CountryTranslations/QatarCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/QatarCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Qatar"),
             new TranslationInfo(LanguageCode.FR, "Qatar"),
             new TranslationInfo(LanguageCode.HE, "קטאר"),
+            new TranslationInfo(LanguageCode.HI, "क़तर"),
             new TranslationInfo(LanguageCode.HR, "Katar"),
             new TranslationInfo(LanguageCode.HU, "Katar"),
             new TranslationInfo(LanguageCode.HY, "Կատար"),

--- a/src/Nager.Country.Translation/CountryTranslations/RepublicOfTheCongoCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/RepublicOfTheCongoCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Kongon tasavalta"),
             new TranslationInfo(LanguageCode.FR, "Congo, République populaire"),
             new TranslationInfo(LanguageCode.HE, "קונגו-ברזאויל"),
+            new TranslationInfo(LanguageCode.HI, "कांगो गणराज्य"),
             new TranslationInfo(LanguageCode.HR, "Kongo-Brazzaville"),
             new TranslationInfo(LanguageCode.HU, "Kongói Köztársaság"),
             new TranslationInfo(LanguageCode.HY, "Կոնգո-Բրազավիլ"),

--- a/src/Nager.Country.Translation/CountryTranslations/ReunionCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/ReunionCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Réunion"),
             new TranslationInfo(LanguageCode.FR, "Réunion"),
             new TranslationInfo(LanguageCode.HE, "ראוניון"),
+            new TranslationInfo(LanguageCode.HI, "रीयूनियन"),
             new TranslationInfo(LanguageCode.HR, "Réunion"),
             new TranslationInfo(LanguageCode.HU, "Réunion"),
             new TranslationInfo(LanguageCode.HY, "Ռեյունիոն"),

--- a/src/Nager.Country.Translation/CountryTranslations/RomaniaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/RomaniaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Romania"),
             new TranslationInfo(LanguageCode.FR, "Roumanie"),
             new TranslationInfo(LanguageCode.HE, "רומניה"),
+            new TranslationInfo(LanguageCode.HI, "रोमानिया"),
             new TranslationInfo(LanguageCode.HR, "Rumunjska"),
             new TranslationInfo(LanguageCode.HU, "Románia"),
             new TranslationInfo(LanguageCode.HY, "Ռումինիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/RussiaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/RussiaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Venäjä"),
             new TranslationInfo(LanguageCode.FR, "Russie"),
             new TranslationInfo(LanguageCode.HE, "רוסיה"),
+            new TranslationInfo(LanguageCode.HI, "रूस"),
             new TranslationInfo(LanguageCode.HR, "Rusija"),
             new TranslationInfo(LanguageCode.HU, "Oroszország"),
             new TranslationInfo(LanguageCode.HY, "Ռուսաստան"),

--- a/src/Nager.Country.Translation/CountryTranslations/RwandaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/RwandaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Ruanda"),
             new TranslationInfo(LanguageCode.FR, "Rwanda"),
             new TranslationInfo(LanguageCode.HE, "רואנדה"),
+            new TranslationInfo(LanguageCode.HI, "रवांडा"),
             new TranslationInfo(LanguageCode.HR, "Ruanda"),
             new TranslationInfo(LanguageCode.HU, "Ruanda"),
             new TranslationInfo(LanguageCode.HY, "Ռուանդա"),

--- a/src/Nager.Country.Translation/CountryTranslations/SaintBarthelemyCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SaintBarthelemyCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Saint-Barthélemy"),
             new TranslationInfo(LanguageCode.FR, "Saint-Barthélemy"),
             new TranslationInfo(LanguageCode.HE, "סנט ברתולומיאו"),
+            new TranslationInfo(LanguageCode.HI, "सेंट बार्थेलेमी"),
             new TranslationInfo(LanguageCode.HR, "Saint Barthélemy"),
             new TranslationInfo(LanguageCode.HU, "Saint Barthélemy"),
             new TranslationInfo(LanguageCode.HY, "Սեն Բարտելմի"),

--- a/src/Nager.Country.Translation/CountryTranslations/SaintHelenaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SaintHelenaCountryTranslation.cs
@@ -16,6 +16,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.NL, "Saint Helena"),
             new TranslationInfo(LanguageCode.RU, "Острова Святой Елены, Вознесения и Тристан-да-Кунья"),
 			new TranslationInfo(LanguageCode.KO, "세인트헬레나"),
+            new TranslationInfo(LanguageCode.HI, "सेंट हेलेना"),
 		};
         
     }

--- a/src/Nager.Country.Translation/CountryTranslations/SaintHelenaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SaintHelenaCountryTranslation.cs
@@ -9,15 +9,15 @@ namespace Nager.Country.Translation.CountryTranslations
         public TranslationInfo[] Translations => new[]
         {
             new TranslationInfo(LanguageCode.DE, "St. Helena"),
-            new TranslationInfo(LanguageCode.FR, "Sainte-Hélène"),
-            new TranslationInfo(LanguageCode.ES, "Santa Elena"),
             new TranslationInfo(LanguageCode.EN, "Saint Helena"),
+            new TranslationInfo(LanguageCode.ES, "Santa Elena"),
+            new TranslationInfo(LanguageCode.FR, "Sainte-Hélène"),
+            new TranslationInfo(LanguageCode.HI, "सेंट हेलेना"),
             new TranslationInfo(LanguageCode.IS, "Sankti Helena"),
+            new TranslationInfo(LanguageCode.KO, "세인트헬레나"),
             new TranslationInfo(LanguageCode.NL, "Saint Helena"),
             new TranslationInfo(LanguageCode.RU, "Острова Святой Елены, Вознесения и Тристан-да-Кунья"),
-			new TranslationInfo(LanguageCode.KO, "세인트헬레나"),
-            new TranslationInfo(LanguageCode.HI, "सेंट हेलेना"),
-		};
+        };
         
     }
 }

--- a/src/Nager.Country.Translation/CountryTranslations/SaintKittsAndNevisCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SaintKittsAndNevisCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Saint Kitts ja Nevis"),
             new TranslationInfo(LanguageCode.FR, "Saint-Christophe-et-Niévès"),
             new TranslationInfo(LanguageCode.HE, "סנט קיטס ונוויס"),
+            new TranslationInfo(LanguageCode.HI, "सेंट किट्स और नेविस"),
             new TranslationInfo(LanguageCode.HR, "Sveti Kristofor i Nevis"),
             new TranslationInfo(LanguageCode.HU, "Saint Kitts és Nevis"),
             new TranslationInfo(LanguageCode.HY, "Սենտ Քիտս և Նևիս"),

--- a/src/Nager.Country.Translation/CountryTranslations/SaintLuciaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SaintLuciaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Saint Lucia"),
             new TranslationInfo(LanguageCode.FR, "Sainte-Lucie"),
             new TranslationInfo(LanguageCode.HE, "סנט לוסיה"),
+            new TranslationInfo(LanguageCode.HI, "सेंट लूसिया"),
             new TranslationInfo(LanguageCode.HR, "Sveta Lucija"),
             new TranslationInfo(LanguageCode.HU, "Saint Lucia"),
             new TranslationInfo(LanguageCode.HY, "Սենթ Լյուսիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/SaintMartinCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SaintMartinCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Saint-Martin"),
             new TranslationInfo(LanguageCode.FR, "Saint-Martin (partie française)"),
             new TranslationInfo(LanguageCode.HE, "סן מרטן"),
+            new TranslationInfo(LanguageCode.HI, "सेंट मार्टिन"),
             new TranslationInfo(LanguageCode.HR, "Saint Martin"),
             new TranslationInfo(LanguageCode.HU, "Szent Márton-sziget (francia rész)"),
             new TranslationInfo(LanguageCode.HY, "Սեն Մարտեն"),

--- a/src/Nager.Country.Translation/CountryTranslations/SaintPierreAndMiquelonCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SaintPierreAndMiquelonCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Saint-Pierre ja Miquelon"),
             new TranslationInfo(LanguageCode.FR, "Saint Pierre and Miquelon"),
             new TranslationInfo(LanguageCode.HE, "סנט פייר ומיקלון"),
+            new TranslationInfo(LanguageCode.HI, "सेंट पियरे और मिकेलॉन"),
             new TranslationInfo(LanguageCode.HR, "Saint-Pierre-et-Miquelon"),
             new TranslationInfo(LanguageCode.HU, "Saint Pierre and Miquelon"),
             new TranslationInfo(LanguageCode.HY, "Սեն Պիեռ և Միքելոն"),

--- a/src/Nager.Country.Translation/CountryTranslations/SaintVincentAndTheGrenadinesCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SaintVincentAndTheGrenadinesCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Saint Vincent ja Grenadiinit"),
             new TranslationInfo(LanguageCode.FR, "Saint-Vincent et les Grenadines"),
             new TranslationInfo(LanguageCode.HE, "סנט וינסנט והגרנדינים"),
+            new TranslationInfo(LanguageCode.HI, "सेंट विंसेंट और ग्रेनेडाइंस"),
             new TranslationInfo(LanguageCode.HR, "Sveti Vincent i Grenadini"),
             new TranslationInfo(LanguageCode.HU, "Saint Vincent és a Grenadine-szigetek"),
             new TranslationInfo(LanguageCode.HY, "Սենթ Վինսենթ և Գրենադիններ"),

--- a/src/Nager.Country.Translation/CountryTranslations/SamoaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SamoaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Samoa"),
             new TranslationInfo(LanguageCode.FR, "Samoa"),
             new TranslationInfo(LanguageCode.HE, "סמואה"),
+            new TranslationInfo(LanguageCode.HI, "समोआ"),
             new TranslationInfo(LanguageCode.HR, "Samoa"),
             new TranslationInfo(LanguageCode.HU, "Szamoa"),
             new TranslationInfo(LanguageCode.HY, "Սամոա"),

--- a/src/Nager.Country.Translation/CountryTranslations/SanMarinoCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SanMarinoCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "San Marino"),
             new TranslationInfo(LanguageCode.FR, "Saint-Marin"),
             new TranslationInfo(LanguageCode.HE, "סן מרינו"),
+            new TranslationInfo(LanguageCode.HI, "सान मारिनो"),
             new TranslationInfo(LanguageCode.HR, "San Marino"),
             new TranslationInfo(LanguageCode.HU, "San Marino"),
             new TranslationInfo(LanguageCode.HY, "Սան Մարինո"),

--- a/src/Nager.Country.Translation/CountryTranslations/SaoTomeAndPrincipeCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SaoTomeAndPrincipeCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "São Tomé ja Príncipe"),
             new TranslationInfo(LanguageCode.FR, "São Tomé et Principe"),
             new TranslationInfo(LanguageCode.HE, "סאו טומה ופרינסיפה"),
+            new TranslationInfo(LanguageCode.HI, "साओ तोमे और प्रिंसिपे"),
             new TranslationInfo(LanguageCode.HR, "Sveti Toma i Princip"),
             new TranslationInfo(LanguageCode.HU, "São Tomé és Príncipe"),
             new TranslationInfo(LanguageCode.HY, "Սան Տոմե և Փրինսիպի"),

--- a/src/Nager.Country.Translation/CountryTranslations/SaudiArabiaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SaudiArabiaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Saudi-Arabia"),
             new TranslationInfo(LanguageCode.FR, "Arabie Saoudite"),
             new TranslationInfo(LanguageCode.HE, "ערב הסעודית"),
+            new TranslationInfo(LanguageCode.HI, "सऊदी अरब"),
             new TranslationInfo(LanguageCode.HR, "Saudijska Arabija"),
             new TranslationInfo(LanguageCode.HU, "Szaudi-Arábia"),
             new TranslationInfo(LanguageCode.HY, "Սաուդյան Արաբիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/SenegalCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SenegalCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Senegal"),
             new TranslationInfo(LanguageCode.FR, "Sénégal"),
             new TranslationInfo(LanguageCode.HE, "סנגל"),
+            new TranslationInfo(LanguageCode.HI, "सेनेगल"),
             new TranslationInfo(LanguageCode.HR, "Senegal"),
             new TranslationInfo(LanguageCode.HU, "Szenegál"),
             new TranslationInfo(LanguageCode.HY, "Սենեգալ"),

--- a/src/Nager.Country.Translation/CountryTranslations/SerbiaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SerbiaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Serbia"),
             new TranslationInfo(LanguageCode.FR, "Serbie"),
             new TranslationInfo(LanguageCode.HE, "סרביה"),
+            new TranslationInfo(LanguageCode.HI, "सर्बिया"),
             new TranslationInfo(LanguageCode.HR, "Srbija"),
             new TranslationInfo(LanguageCode.HU, "Szerbia"),
             new TranslationInfo(LanguageCode.HY, "Սերբիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/SeychellesCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SeychellesCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Seychellit"),
             new TranslationInfo(LanguageCode.FR, "Seychelles"),
             new TranslationInfo(LanguageCode.HE, "איי סיישל"),
+            new TranslationInfo(LanguageCode.HI, "सेशेल्स"),
             new TranslationInfo(LanguageCode.HR, "Sejšeli"),
             new TranslationInfo(LanguageCode.HU, "Seychelle-szigetek"),
             new TranslationInfo(LanguageCode.HY, "Սեյշելներ"),

--- a/src/Nager.Country.Translation/CountryTranslations/SierraLeoneCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SierraLeoneCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Sierra Leone"),
             new TranslationInfo(LanguageCode.FR, "Sierra Leone"),
             new TranslationInfo(LanguageCode.HE, "סיירה לאונה"),
+            new TranslationInfo(LanguageCode.HI, "सियरा लियोन"),
             new TranslationInfo(LanguageCode.HR, "Sijera Leone"),
             new TranslationInfo(LanguageCode.HU, "Sierra Leone"),
             new TranslationInfo(LanguageCode.HY, "Սիեռա Լեոնե"),

--- a/src/Nager.Country.Translation/CountryTranslations/SingaporeCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SingaporeCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Singapore"),
             new TranslationInfo(LanguageCode.FR, "Singapour"),
             new TranslationInfo(LanguageCode.HE, "סינגפור"),
+            new TranslationInfo(LanguageCode.HI, "सिंगापुर"),
             new TranslationInfo(LanguageCode.HR, "Singapur"),
             new TranslationInfo(LanguageCode.HU, "Szingapúr"),
             new TranslationInfo(LanguageCode.HY, "Սինգապուր"),

--- a/src/Nager.Country.Translation/CountryTranslations/SintMaartenCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SintMaartenCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Sint Maarten"),
             new TranslationInfo(LanguageCode.FR, "Saint-Martin (partie néerlandaise)"),
             new TranslationInfo(LanguageCode.HE, "סנט מארטן"),
+            new TranslationInfo(LanguageCode.HI, "सिंट मार्टेन"),
             new TranslationInfo(LanguageCode.HR, "Sint Maarten"),
             new TranslationInfo(LanguageCode.HU, "Szent Márton-sziget (holland rész)"),
             new TranslationInfo(LanguageCode.HY, "Սինտ Մարտեն"),

--- a/src/Nager.Country.Translation/CountryTranslations/SlovakiaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SlovakiaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Slovakia"),
             new TranslationInfo(LanguageCode.FR, "Slovaquie"),
             new TranslationInfo(LanguageCode.HE, "סלובקיה"),
+            new TranslationInfo(LanguageCode.HI, "स्लोवाकिया"),
             new TranslationInfo(LanguageCode.HR, "Slovačka"),
             new TranslationInfo(LanguageCode.HU, "Szlovákia"),
             new TranslationInfo(LanguageCode.HY, "Սլովակիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/SloveniaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SloveniaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Slovenia"),
             new TranslationInfo(LanguageCode.FR, "Slovénie"),
             new TranslationInfo(LanguageCode.HE, "סלובניה"),
+            new TranslationInfo(LanguageCode.HI, "स्लोवेनिया"),
             new TranslationInfo(LanguageCode.HR, "Slovenija"),
             new TranslationInfo(LanguageCode.HU, "Szlovénia"),
             new TranslationInfo(LanguageCode.HY, "Սլովենիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/SolomonIslandsCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SolomonIslandsCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Salomonsaaret"),
             new TranslationInfo(LanguageCode.FR, "Salomon"),
             new TranslationInfo(LanguageCode.HE, "איי שלמה"),
+            new TranslationInfo(LanguageCode.HI, "सोलोमन द्वीपसमूह"),
             new TranslationInfo(LanguageCode.HR, "Salomonski Otoci"),
             new TranslationInfo(LanguageCode.HU, "Salamon-szigetek"),
             new TranslationInfo(LanguageCode.HY, "Սողոմոնյան կղզիներ"),

--- a/src/Nager.Country.Translation/CountryTranslations/SomaliaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SomaliaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Somalia"),
             new TranslationInfo(LanguageCode.FR, "Somalie"),
             new TranslationInfo(LanguageCode.HE, "סומליה"),
+            new TranslationInfo(LanguageCode.HI, "सोमालिया"),
             new TranslationInfo(LanguageCode.HR, "Somalija"),
             new TranslationInfo(LanguageCode.HU, "Szomália"),
             new TranslationInfo(LanguageCode.HY, "Սոմալի"),

--- a/src/Nager.Country.Translation/CountryTranslations/SouthAfricaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SouthAfricaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Etelä-Afrikka"),
             new TranslationInfo(LanguageCode.FR, "Afrique du Sud"),
             new TranslationInfo(LanguageCode.HE, "דרום אפריקה"),
+            new TranslationInfo(LanguageCode.HI, "दक्षिण अफ़्रीका"),
             new TranslationInfo(LanguageCode.HR, "Južnoafrička Republika"),
             new TranslationInfo(LanguageCode.HU, "Dél-Afrika"),
             new TranslationInfo(LanguageCode.HY, "Հարավաֆրիկյան Հանրապետություն"),

--- a/src/Nager.Country.Translation/CountryTranslations/SouthGeorgiaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SouthGeorgiaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Etelä-Georgia ja Eteläiset Sandwichsaaret"),
             new TranslationInfo(LanguageCode.FR, "Géorgie du Sud-et-les Îles Sandwich du Sud"),
             new TranslationInfo(LanguageCode.HE, "ג׳ורג׳יה הדרומית ואיי סנדוויץ׳ הדרומיים"),
+            new TranslationInfo(LanguageCode.HI, "दक्षिण जॉर्जिया"),
             new TranslationInfo(LanguageCode.HR, "Južna Georgija i Južni Sendvički Otoci"),
             new TranslationInfo(LanguageCode.HU, "Déli-Georgia és Déli-Sandwich-szigetek"),
             new TranslationInfo(LanguageCode.HY, "Հարավային Ջորջիա և Հարավային Սենդվիչյան կղզիներ"),

--- a/src/Nager.Country.Translation/CountryTranslations/SouthKoreaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SouthKoreaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Korean tasavalta"),
             new TranslationInfo(LanguageCode.FR, "Corée du Sud, République"),
             new TranslationInfo(LanguageCode.HE, "קוריאה הדרומית"),
+            new TranslationInfo(LanguageCode.HI, "दक्षिण कोरिया"),
             new TranslationInfo(LanguageCode.HR, "Južna Koreja"),
             new TranslationInfo(LanguageCode.HU, "Dél-Korea"),
             new TranslationInfo(LanguageCode.HY, "Հարավային Կորեա"),

--- a/src/Nager.Country.Translation/CountryTranslations/SouthSudanCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SouthSudanCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Etelä-Sudan"),
             new TranslationInfo(LanguageCode.FR, "Sud-Soudan"),
             new TranslationInfo(LanguageCode.HE, "דרום סודן"),
+            new TranslationInfo(LanguageCode.HI, "दक्षिण सूडान"),
             new TranslationInfo(LanguageCode.HR, "Južni Sudan"),
             new TranslationInfo(LanguageCode.HU, "Dél-Szudán"),
             new TranslationInfo(LanguageCode.HY, "Հարավային Սուդան"),

--- a/src/Nager.Country.Translation/CountryTranslations/SpainCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SpainCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Espanja"),
             new TranslationInfo(LanguageCode.FR, "Espagne"),
             new TranslationInfo(LanguageCode.HE, "ספרד"),
+            new TranslationInfo(LanguageCode.HI, "स्पेन"),
             new TranslationInfo(LanguageCode.HR, "Španjolska"),
             new TranslationInfo(LanguageCode.HU, "Spanyolország"),
             new TranslationInfo(LanguageCode.HY, "Իսպանիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/SriLankaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SriLankaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Sri Lanka"),
             new TranslationInfo(LanguageCode.FR, "Sri Lanka"),
             new TranslationInfo(LanguageCode.HE, "סרי לנקה"),
+            new TranslationInfo(LanguageCode.HI, "श्रीलंका"),
             new TranslationInfo(LanguageCode.HR, "Šri Lanka"),
             new TranslationInfo(LanguageCode.HU, "Sri Lanka"),
             new TranslationInfo(LanguageCode.HY, "Շրի Լանկա"),

--- a/src/Nager.Country.Translation/CountryTranslations/SudanCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SudanCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Sudan"),
             new TranslationInfo(LanguageCode.FR, "Soudan"),
             new TranslationInfo(LanguageCode.HE, "סודן"),
+            new TranslationInfo(LanguageCode.HI, "सूडान"),
             new TranslationInfo(LanguageCode.HR, "Sudan"),
             new TranslationInfo(LanguageCode.HU, "Szudán"),
             new TranslationInfo(LanguageCode.HY, "Սուդան"),

--- a/src/Nager.Country.Translation/CountryTranslations/SurinameCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SurinameCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Suriname"),
             new TranslationInfo(LanguageCode.FR, "Suriname"),
             new TranslationInfo(LanguageCode.HE, "סורינם"),
+            new TranslationInfo(LanguageCode.HI, "सूरीनाम"),
             new TranslationInfo(LanguageCode.HR, "Surinam"),
             new TranslationInfo(LanguageCode.HU, "Suriname"),
             new TranslationInfo(LanguageCode.HY, "Սուրինամ"),

--- a/src/Nager.Country.Translation/CountryTranslations/SvalbardAndJanMayenCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SvalbardAndJanMayenCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Svalbard ja Jan Mayen"),
             new TranslationInfo(LanguageCode.FR, "Svalbard et Île Jan Mayen"),
             new TranslationInfo(LanguageCode.HE, "סוולבארד ויאן מאיין"),
+            new TranslationInfo(LanguageCode.HI, "स्वालबार्ड और जान मायेन"),
             new TranslationInfo(LanguageCode.HR, "Svalbard i Jan Mayen"),
             new TranslationInfo(LanguageCode.HU, "Spitzbergák és Jan Mayen"),
             new TranslationInfo(LanguageCode.HY, "Սվալբարդ և Յան Մայեն"),

--- a/src/Nager.Country.Translation/CountryTranslations/SwedenCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SwedenCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Ruotsi"),
             new TranslationInfo(LanguageCode.FR, "Suède"),
             new TranslationInfo(LanguageCode.HE, "שוודיה"),
+            new TranslationInfo(LanguageCode.HI, "स्वीडन"),
             new TranslationInfo(LanguageCode.HR, "Švedska"),
             new TranslationInfo(LanguageCode.HU, "Svédország"),
             new TranslationInfo(LanguageCode.HY, "Շվեդիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/SwitzerlandCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SwitzerlandCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Sveitsi"),
             new TranslationInfo(LanguageCode.FR, "Suisse"),
             new TranslationInfo(LanguageCode.HE, "שווייץ"),
+            new TranslationInfo(LanguageCode.HI, "स्विट्ज़रलैंड"),
             new TranslationInfo(LanguageCode.HR, "Švicarska"),
             new TranslationInfo(LanguageCode.HU, "Svájc"),
             new TranslationInfo(LanguageCode.HY, "Շվեյցարիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/SyriaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/SyriaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Syyria"),
             new TranslationInfo(LanguageCode.FR, "Syrie"),
             new TranslationInfo(LanguageCode.HE, "סוריה"),
+            new TranslationInfo(LanguageCode.HI, "सीरिया"),
             new TranslationInfo(LanguageCode.HR, "Sirija"),
             new TranslationInfo(LanguageCode.HU, "Szíria"),
             new TranslationInfo(LanguageCode.HY, "Սիրիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/TaiwanCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/TaiwanCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Taiwan"),
             new TranslationInfo(LanguageCode.FR, "Taïwan"),
             new TranslationInfo(LanguageCode.HE, "טייוואן"),
+            new TranslationInfo(LanguageCode.HI, "ताइवान"),
             new TranslationInfo(LanguageCode.HR, "Tajvan"),
             new TranslationInfo(LanguageCode.HU, "Tajvan"),
             new TranslationInfo(LanguageCode.HY, "Թայվան"),

--- a/src/Nager.Country.Translation/CountryTranslations/TajikistanCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/TajikistanCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Tadžikistan"),
             new TranslationInfo(LanguageCode.FR, "Tadjikistan"),
             new TranslationInfo(LanguageCode.HE, "טג׳יקיסטן"),
+            new TranslationInfo(LanguageCode.HI, "ताजिकिस्तान"),
             new TranslationInfo(LanguageCode.HR, "Tadžikistan"),
             new TranslationInfo(LanguageCode.HU, "Tádzsikisztán"),
             new TranslationInfo(LanguageCode.HY, "Տաջիկստան"),

--- a/src/Nager.Country.Translation/CountryTranslations/TanzaniaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/TanzaniaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Tansania"),
             new TranslationInfo(LanguageCode.FR, "Tanzanie, République unie"),
             new TranslationInfo(LanguageCode.HE, "טנזניה"),
+            new TranslationInfo(LanguageCode.HI, "तंज़ानिया"),
             new TranslationInfo(LanguageCode.HR, "Tanzanija"),
             new TranslationInfo(LanguageCode.HU, "Tanzánia"),
             new TranslationInfo(LanguageCode.HY, "Տանզանիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/ThailandCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/ThailandCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Thaimaa"),
             new TranslationInfo(LanguageCode.FR, "Thaïlande"),
             new TranslationInfo(LanguageCode.HE, "תאילנד"),
+            new TranslationInfo(LanguageCode.HI, "थाईलैंड"),
             new TranslationInfo(LanguageCode.HR, "Tajland"),
             new TranslationInfo(LanguageCode.HU, "Thaiföld"),
             new TranslationInfo(LanguageCode.HY, "Թայլանդ"),

--- a/src/Nager.Country.Translation/CountryTranslations/TimorLesteCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/TimorLesteCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Itä-Timor"),
             new TranslationInfo(LanguageCode.FR, "Timor Leste"),
             new TranslationInfo(LanguageCode.HE, "טימור לסטה"),
+            new TranslationInfo(LanguageCode.HI, "तिमोर-लेस्ते"),
             new TranslationInfo(LanguageCode.HR, "Timor-Leste"),
             new TranslationInfo(LanguageCode.HU, "Kelet-Timor"),
             new TranslationInfo(LanguageCode.HY, "Թիմոր Լեշտի"),

--- a/src/Nager.Country.Translation/CountryTranslations/TogoCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/TogoCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Togo"),
             new TranslationInfo(LanguageCode.FR, "Togo"),
             new TranslationInfo(LanguageCode.HE, "טוגו"),
+            new TranslationInfo(LanguageCode.HI, "टोगो"),
             new TranslationInfo(LanguageCode.HR, "Togo"),
             new TranslationInfo(LanguageCode.HU, "Togo"),
             new TranslationInfo(LanguageCode.HY, "Տոգո"),

--- a/src/Nager.Country.Translation/CountryTranslations/TokelauCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/TokelauCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Tokelau"),
             new TranslationInfo(LanguageCode.FR, "Tokelau"),
             new TranslationInfo(LanguageCode.HE, "טוקלאו"),
+            new TranslationInfo(LanguageCode.HI, "टोकेलाऊ"),
             new TranslationInfo(LanguageCode.HR, "Tokelau"),
             new TranslationInfo(LanguageCode.HU, "Tokelau-szigetek"),
             new TranslationInfo(LanguageCode.HY, "Տոկելաու"),

--- a/src/Nager.Country.Translation/CountryTranslations/TongaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/TongaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Tonga"),
             new TranslationInfo(LanguageCode.FR, "Tonga"),
             new TranslationInfo(LanguageCode.HE, "טונגה"),
+            new TranslationInfo(LanguageCode.HI, "टोंगा"),
             new TranslationInfo(LanguageCode.HR, "Tonga"),
             new TranslationInfo(LanguageCode.HU, "Tonga"),
             new TranslationInfo(LanguageCode.HY, "Տոնգա"),

--- a/src/Nager.Country.Translation/CountryTranslations/TrinidadAndTobagoCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/TrinidadAndTobagoCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Trinidad ja Tobago"),
             new TranslationInfo(LanguageCode.FR, "Trinidad et Tobago"),
             new TranslationInfo(LanguageCode.HE, "טרינידד וטובגו"),
+            new TranslationInfo(LanguageCode.HI, "त्रिनिदाद और टोबैगो"),
             new TranslationInfo(LanguageCode.HR, "Trinidad i Tobago"),
             new TranslationInfo(LanguageCode.HU, "Trinidad és Tobago"),
             new TranslationInfo(LanguageCode.HY, "Տրինիդադ և Տոբագո"),

--- a/src/Nager.Country.Translation/CountryTranslations/TunisiaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/TunisiaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Tunisia"),
             new TranslationInfo(LanguageCode.FR, "Tunisie"),
             new TranslationInfo(LanguageCode.HE, "טוניסיה"),
+            new TranslationInfo(LanguageCode.HI, "ट्यूनीशिया"),
             new TranslationInfo(LanguageCode.HR, "Tunis"),
             new TranslationInfo(LanguageCode.HU, "Tunézia"),
             new TranslationInfo(LanguageCode.HY, "Թունիս"),

--- a/src/Nager.Country.Translation/CountryTranslations/TurkeyCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/TurkeyCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Turkki"),
             new TranslationInfo(LanguageCode.FR, "Turquie"),
             new TranslationInfo(LanguageCode.HE, "טורקיה"),
+            new TranslationInfo(LanguageCode.HI, "तुर्की"),
             new TranslationInfo(LanguageCode.HR, "Turska"),
             new TranslationInfo(LanguageCode.HU, "Törökország"),
             new TranslationInfo(LanguageCode.HY, "Թուրքիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/TurkmenistanCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/TurkmenistanCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Turkmenistan"),
             new TranslationInfo(LanguageCode.FR, "Turkménistan"),
             new TranslationInfo(LanguageCode.HE, "טורקמניסטן"),
+            new TranslationInfo(LanguageCode.HI, "तुर्कमेनिस्तान"),
             new TranslationInfo(LanguageCode.HR, "Turkmenistan"),
             new TranslationInfo(LanguageCode.HU, "Türkmenisztán"),
             new TranslationInfo(LanguageCode.HY, "Թուրքմենստան"),

--- a/src/Nager.Country.Translation/CountryTranslations/TurksAndCaicosIslandsCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/TurksAndCaicosIslandsCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Turks- ja Caicossaaret"),
             new TranslationInfo(LanguageCode.FR, "Îles Turques-et-Caïques"),
             new TranslationInfo(LanguageCode.HE, "איי טורקס וקאיקוס"),
+            new TranslationInfo(LanguageCode.HI, "तुर्क्स और कैकोस द्वीपसमूह"),
             new TranslationInfo(LanguageCode.HR, "Otoci Turks i Caicos"),
             new TranslationInfo(LanguageCode.HU, "Turks- és Caicos-szigetek"),
             new TranslationInfo(LanguageCode.HY, "Թըրքս և Կայկոս կղզիներ"),

--- a/src/Nager.Country.Translation/CountryTranslations/TuvaluCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/TuvaluCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Tuvalu"),
             new TranslationInfo(LanguageCode.FR, "Tuvalu"),
             new TranslationInfo(LanguageCode.HE, "טובאלו"),
+            new TranslationInfo(LanguageCode.HI, "तुवालू"),
             new TranslationInfo(LanguageCode.HR, "Tuvalu"),
             new TranslationInfo(LanguageCode.HU, "Tuvalu"),
             new TranslationInfo(LanguageCode.HY, "Տուվալու"),

--- a/src/Nager.Country.Translation/CountryTranslations/UgandaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/UgandaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Uganda"),
             new TranslationInfo(LanguageCode.FR, "Ouganda"),
             new TranslationInfo(LanguageCode.HE, "אוגנדה"),
+            new TranslationInfo(LanguageCode.HI, "युगांडा"),
             new TranslationInfo(LanguageCode.HR, "Uganda"),
             new TranslationInfo(LanguageCode.HU, "Uganda"),
             new TranslationInfo(LanguageCode.HY, "Ուգանդա"),

--- a/src/Nager.Country.Translation/CountryTranslations/UkraineCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/UkraineCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Ukraina"),
             new TranslationInfo(LanguageCode.FR, "Ukraine"),
             new TranslationInfo(LanguageCode.HE, "אוקראינה"),
+            new TranslationInfo(LanguageCode.HI, "यूक्रेन"),
             new TranslationInfo(LanguageCode.HR, "Ukrajina"),
             new TranslationInfo(LanguageCode.HU, "Ukrajna"),
             new TranslationInfo(LanguageCode.HY, "Ուկրաինա"),

--- a/src/Nager.Country.Translation/CountryTranslations/UnitedArabEmiratesCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/UnitedArabEmiratesCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Arabiemiirikunnat"),
             new TranslationInfo(LanguageCode.FR, "Émirats Arabes Unis"),
             new TranslationInfo(LanguageCode.HE, "איחוד האמירויות הערביות"),
+            new TranslationInfo(LanguageCode.HI, "संयुक्त अरब अमीरात"),
             new TranslationInfo(LanguageCode.HR, "Ujedinjeni Arapski Emirati"),
             new TranslationInfo(LanguageCode.HU, "Egyesült Arab Emírségek"),
             new TranslationInfo(LanguageCode.HY, "Արաբական Միացյալ Էմիրություններ"),

--- a/src/Nager.Country.Translation/CountryTranslations/UnitedKingdomCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/UnitedKingdomCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Yhdistynyt kuningaskunta"),
             new TranslationInfo(LanguageCode.FR, "Royaume-Uni"),
             new TranslationInfo(LanguageCode.HE, "הממלכה המאוחדת"),
+            new TranslationInfo(LanguageCode.HI, "यूनाइटेड किंगडम"),
             new TranslationInfo(LanguageCode.HR, "Ujedinjeno Kraljevstvo"),
             new TranslationInfo(LanguageCode.HU, "Egyesült Királyság"),
             new TranslationInfo(LanguageCode.HY, "Միացյալ Թագավորություն"),

--- a/src/Nager.Country.Translation/CountryTranslations/UnitedStatesCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/UnitedStatesCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Yhdysvallat"),
             new TranslationInfo(LanguageCode.FR, "États-Unis d'Amérique"),
             new TranslationInfo(LanguageCode.HE, "ארצות הברית"),
+            new TranslationInfo(LanguageCode.HI, "संयुक्त राज्य अमेरिका"),
             new TranslationInfo(LanguageCode.HR, "Sjedinjene Američke Države"),
             new TranslationInfo(LanguageCode.HU, "Amerikai Egyesült Államok"),
             new TranslationInfo(LanguageCode.HY, "Միացյալ Նահանգներ"),

--- a/src/Nager.Country.Translation/CountryTranslations/UnitedStatesMinorOutlyingIslandsCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/UnitedStatesMinorOutlyingIslandsCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Yhdysvaltain pienet erillissaaret"),
             new TranslationInfo(LanguageCode.FR, "Îles mineures éloignées des États-Unis"),
             new TranslationInfo(LanguageCode.HE, "האיים המרוחקים הקטנים של ארה״ב"),
+            new TranslationInfo(LanguageCode.HI, "संयुक्त राज्य के छोटे बाहरी द्वीपसमूह"),
             new TranslationInfo(LanguageCode.HR, "Mali udaljeni otoci SAD-a"),
             new TranslationInfo(LanguageCode.HU, "Az Amerikai Egyesült Államok lakatlan külbirtokai"),
             new TranslationInfo(LanguageCode.HY, "Արտաքին կղզիներ (ԱՄՆ)"),

--- a/src/Nager.Country.Translation/CountryTranslations/UnitedStatesVirginIslandsCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/UnitedStatesVirginIslandsCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Yhdysvaltain Neitsytsaaret"),
             new TranslationInfo(LanguageCode.FR, "Îles vierges américaines"),
             new TranslationInfo(LanguageCode.HE, "איי הבתולה של ארצות הברית"),
+            new TranslationInfo(LanguageCode.HI, "संयुक्त राज्य वर्जिन द्वीपसमूह"),
             new TranslationInfo(LanguageCode.HR, "Američki Djevičanski otoci"),
             new TranslationInfo(LanguageCode.HU, "Amerikai Virgin-szigetek"),
             new TranslationInfo(LanguageCode.HY, "ԱՄՆ Վիրջինյան կղզիներ"),

--- a/src/Nager.Country.Translation/CountryTranslations/UruguayCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/UruguayCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Uruguay"),
             new TranslationInfo(LanguageCode.FR, "Uruguay"),
             new TranslationInfo(LanguageCode.HE, "אורוגוואי"),
+            new TranslationInfo(LanguageCode.HI, "उरुग्वे"),
             new TranslationInfo(LanguageCode.HR, "Urugvaj"),
             new TranslationInfo(LanguageCode.HU, "Uruguay"),
             new TranslationInfo(LanguageCode.HY, "Ուրուգվայ"),

--- a/src/Nager.Country.Translation/CountryTranslations/UzbekistanCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/UzbekistanCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Uzbekistan"),
             new TranslationInfo(LanguageCode.FR, "Ouzbékistan"),
             new TranslationInfo(LanguageCode.HE, "אוזבקיסטן"),
+            new TranslationInfo(LanguageCode.HI, "उज़्बेकिस्तान"),
             new TranslationInfo(LanguageCode.HR, "Uzbekistan"),
             new TranslationInfo(LanguageCode.HU, "Üzbegisztán"),
             new TranslationInfo(LanguageCode.HY, "Ուզբեկստան"),

--- a/src/Nager.Country.Translation/CountryTranslations/VanuatuCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/VanuatuCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Vanuatu"),
             new TranslationInfo(LanguageCode.FR, "Vanuatu"),
             new TranslationInfo(LanguageCode.HE, "ונואטו"),
+            new TranslationInfo(LanguageCode.HI, "वानुअतु"),
             new TranslationInfo(LanguageCode.HR, "Vanuatu"),
             new TranslationInfo(LanguageCode.HU, "Vanuatu"),
             new TranslationInfo(LanguageCode.HY, "Վանուատու"),

--- a/src/Nager.Country.Translation/CountryTranslations/VaticanCityCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/VaticanCityCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Vatikaanivaltio"),
             new TranslationInfo(LanguageCode.FR, "Saint-Siège"),
             new TranslationInfo(LanguageCode.HE, "הוותיקן"),
+            new TranslationInfo(LanguageCode.HI, "वेटिकन सिटी"),
             new TranslationInfo(LanguageCode.HR, "Vatikanski Grad"),
             new TranslationInfo(LanguageCode.HU, "Vatikán"),
             new TranslationInfo(LanguageCode.HY, "Վատիկան"),

--- a/src/Nager.Country.Translation/CountryTranslations/VenezuelaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/VenezuelaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Venezuela"),
             new TranslationInfo(LanguageCode.FR, "Venezuela"),
             new TranslationInfo(LanguageCode.HE, "ונצואלה"),
+            new TranslationInfo(LanguageCode.HI, "वेनेज़ुएला"),
             new TranslationInfo(LanguageCode.HR, "Venezuela"),
             new TranslationInfo(LanguageCode.HU, "Venezuela"),
             new TranslationInfo(LanguageCode.HY, "Վենեսուելա"),

--- a/src/Nager.Country.Translation/CountryTranslations/VietnamCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/VietnamCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Vietnam"),
             new TranslationInfo(LanguageCode.FR, "Vietnam"),
             new TranslationInfo(LanguageCode.HE, "וייטנאם"),
+            new TranslationInfo(LanguageCode.HI, "वियतनाम"),
             new TranslationInfo(LanguageCode.HR, "Vijetnam"),
             new TranslationInfo(LanguageCode.HU, "Vietnam"),
             new TranslationInfo(LanguageCode.HY, "Վիետնամ"),

--- a/src/Nager.Country.Translation/CountryTranslations/WallisAndFutunaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/WallisAndFutunaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Wallis ja Futunasaaret"),
             new TranslationInfo(LanguageCode.FR, "Wallis et Futuna"),
             new TranslationInfo(LanguageCode.HE, "איי ווליס ופוטונה"),
+            new TranslationInfo(LanguageCode.HI, "वालिस और फुतुना"),
             new TranslationInfo(LanguageCode.HR, "Wallis i Futuna"),
             new TranslationInfo(LanguageCode.HU, "Wallis és Futuna"),
             new TranslationInfo(LanguageCode.HY, "Ուոլիս և Ֆուտունա"),

--- a/src/Nager.Country.Translation/CountryTranslations/WesternSaharaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/WesternSaharaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Länsi-Sahara"),
             new TranslationInfo(LanguageCode.FR, "Sahara occidental"),
             new TranslationInfo(LanguageCode.HE, "סהרה המערבית"),
+            new TranslationInfo(LanguageCode.HI, "पश्चिमी सहारा"),
             new TranslationInfo(LanguageCode.HR, "Zapadna Sahara"),
             new TranslationInfo(LanguageCode.HU, "Nyugat-Szahara"),
             new TranslationInfo(LanguageCode.HY, "Արևմտյան Սահարա"),

--- a/src/Nager.Country.Translation/CountryTranslations/YemenCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/YemenCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Jemen"),
             new TranslationInfo(LanguageCode.FR, "Yémen"),
             new TranslationInfo(LanguageCode.HE, "תימן"),
+            new TranslationInfo(LanguageCode.HI, "यमन"),
             new TranslationInfo(LanguageCode.HR, "Jemen"),
             new TranslationInfo(LanguageCode.HU, "Jemen"),
             new TranslationInfo(LanguageCode.HY, "Եմեն"),

--- a/src/Nager.Country.Translation/CountryTranslations/ZambiaCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/ZambiaCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Sambia"),
             new TranslationInfo(LanguageCode.FR, "Zambie"),
             new TranslationInfo(LanguageCode.HE, "זמביה"),
+            new TranslationInfo(LanguageCode.HI, "ज़ाम्बिया"),
             new TranslationInfo(LanguageCode.HR, "Zambija"),
             new TranslationInfo(LanguageCode.HU, "Zambia"),
             new TranslationInfo(LanguageCode.HY, "Զամբիա"),

--- a/src/Nager.Country.Translation/CountryTranslations/ZimbabweCountryTranslation.cs
+++ b/src/Nager.Country.Translation/CountryTranslations/ZimbabweCountryTranslation.cs
@@ -25,6 +25,7 @@ namespace Nager.Country.Translation.CountryTranslations
             new TranslationInfo(LanguageCode.FI, "Zimbabwe"),
             new TranslationInfo(LanguageCode.FR, "Zimbabwe"),
             new TranslationInfo(LanguageCode.HE, "זימבבואה"),
+            new TranslationInfo(LanguageCode.HI, "ज़िम्बाब्वे"),
             new TranslationInfo(LanguageCode.HR, "Zimbabve"),
             new TranslationInfo(LanguageCode.HU, "Zimbabwe"),
             new TranslationInfo(LanguageCode.HY, "Զիմբաբվե"),


### PR DESCRIPTION
Add Hindi (LanguageCode.HI) translation entries to the country translation classes under src/Nager.Country.Translation/CountryTranslations. This commit inserts new TranslationInfo(LanguageCode.HI, ...) entries for many countries to provide Hindi localized names; it is a data-only change to expand supported languages.